### PR TITLE
adding data store permissions

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
@@ -79,8 +79,8 @@ public class GeoPackageStore extends SCDataStore {
     }
 
     @Override
-    public int getAuthorization() {
-        return 6;
+    public DataStorePermissionEnum getAuthorization() {
+        return DataStorePermissionEnum.READ_WRITE;
     }
 
     @Override

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCDataStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCDataStore.java
@@ -56,8 +56,8 @@ public abstract class SCDataStore implements SCSpatialStore
         }
     }
 
-    public int getAuthorization() {
-        return 4;
+    public DataStorePermissionEnum getAuthorization() {
+        return DataStorePermissionEnum.READ;
     }
 
     public SCDataAdapter getAdapter()
@@ -152,5 +152,9 @@ public abstract class SCDataStore implements SCSpatialStore
     @Override
     public String toString() {
         return storeId + "." + name;
+    }
+
+    public enum DataStorePermissionEnum {
+        READ, READ_WRITE
     }
 }


### PR DESCRIPTION
All stores have READ permission by default.  If a store wants to allow READ_WRITE permission, it needs to override the method in its implementation