### PR TITLE
Adding static types to the Observables to keep the GeoPackageStore interface explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 before_script:
   - android list targets
   - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
+  - emulator -avd test -no-audio -no-window -memory 2048 &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/dataAdapter/GeoPackageAdapter.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/dataAdapter/GeoPackageAdapter.java
@@ -346,7 +346,7 @@ public class GeoPackageAdapter extends SCDataAdapter {
      * @param scSpatialFeature the feature to update
      * @return an observable of the update feature
      */
-    public Observable update(final SCSpatialFeature scSpatialFeature) {
+    public Observable<SCSpatialFeature> update(final SCSpatialFeature scSpatialFeature) {
         final String tableName = scSpatialFeature.getKey().getLayerId();
         final SCGpkgFeatureSource featureSource = getFeatureSourceByName(tableName);
         if (featureSource == null) {
@@ -388,7 +388,7 @@ public class GeoPackageAdapter extends SCDataAdapter {
      * @param keyTuple the {@link SCKeyTuple} of the feature to delete
      * @return onCompleted if delete is successful, onError if not
      */
-    public Observable delete(final SCKeyTuple keyTuple) {
+    public Observable<Void> delete(final SCKeyTuple keyTuple) {
         final String tableName = keyTuple.getLayerId();
         final SCGpkgFeatureSource featureSource = getFeatureSourceByName(tableName);
         if (featureSource == null) {
@@ -400,9 +400,9 @@ public class GeoPackageAdapter extends SCDataAdapter {
             );
         }
         else {
-            return Observable.create(new Observable.OnSubscribe<SCSpatialFeature>() {
+            return Observable.create(new Observable.OnSubscribe<Void>() {
                 @Override
-                public void call(Subscriber<? super SCSpatialFeature> subscriber) {
+                public void call(Subscriber<? super Void> subscriber) {
                     try {
                         gpkg.executeAndTrigger(tableName,
                                 String.format("DELETE FROM %s WHERE %s = %s",

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
@@ -81,12 +81,12 @@ public class GeoPackageStore extends SCDataStore {
     }
 
     @Override
-    public Observable<Boolean> update(final SCSpatialFeature scSpatialFeature) {
+    public Observable<SCSpatialFeature> update(final SCSpatialFeature scSpatialFeature) {
         return ((GeoPackageAdapter) getAdapter()).update(scSpatialFeature);
     }
 
     @Override
-    public Observable<Boolean> delete(final SCKeyTuple keyTuple) {
+    public Observable<Void> delete(final SCKeyTuple keyTuple) {
         return ((GeoPackageAdapter) getAdapter()).delete(keyTuple);
     }
 


### PR DESCRIPTION
## Status
**READY**

## Description
This PR adds static typing to the Observables for the GeoPackageStore.

## Todos
- [x] Tests
- [x] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout typed-observables
```

## Impacted Areas in Application

* Any subscribers to these observables will need to ensure they are using the new types. 

@boundlessgeo/spatial-connect
