### PR TITLE
adding react native bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ android:
     - addon-google_apis-google-23
 
     # specify emulator to run during your tests
-    - sys-img-armeabi-v7a-android-23
+    - sys-img-armeabi-v7a-android-19
 
   licenses:
     - 'android-sdk-license-.+'

--- a/spatialconnect/build.gradle
+++ b/spatialconnect/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'maven'
 group 'com.boundlessgeo.spatialconnect'
 version '1.0.0'
 
+def isCi = "true".equals(System.getenv("CI"))
+def preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
+
 android {
     compileSdkVersion 'Google Inc.:Google APIs:23'
     buildToolsVersion '23.0.1'
@@ -13,7 +16,8 @@ android {
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        // http://developer.android.com/tools/building/multidex.html#testing
+        testInstrumentationRunner "com.boundlessgeo.spatialconnect.test.MultiDexAndroidJUnitRunner"
     }
     lintOptions {
         abortOnError false
@@ -50,7 +54,8 @@ android {
         main.jniLibs.srcDirs = ['libs']
     }
     dexOptions {
-        javaMaxHeapSize "2g"
+        // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
+        preDexLibraries = preDexEnabled && !isCi
     }
 }
 
@@ -62,11 +67,13 @@ repositories {
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.google.android.gms:play-services-maps:7.8.0'
+    compile 'com.android.support:multidex:1.0.1'
     compile 'com.bedatadriven:jackson-datatype-jts:1.0'
     compile 'io.reactivex:rxandroid:1.1.0'
     compile 'io.reactivex:rxjava:1.1.0'
     compile 'commons-io:commons-io:2.4'
     compile 'com.squareup.okhttp3:okhttp:3.2.0'
+    compile "com.facebook.react:react-native:+"
     compile('io.jeo:jeo:0.6') {
         exclude group: 'com.vividsolutions'
         exclude group: 'io.jeo', module: 'proj4j'

--- a/spatialconnect/src/androidTest/AndroidManifest.xml
+++ b/spatialconnect/src/androidTest/AndroidManifest.xml
@@ -6,7 +6,8 @@
 
     <application
         android:allowBackup="true"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:name="android.support.multidex.MultiDexApplication">
         <!-- setup the activity used for testing -->
         <activity
             android:name="com.boundlessgeo.spatialconnect.SpatialConnectActivity">

--- a/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/MultiDexAndroidJUnitRunner.java
+++ b/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/MultiDexAndroidJUnitRunner.java
@@ -1,0 +1,16 @@
+package com.boundlessgeo.spatialconnect.test;
+
+import android.os.Bundle;
+import android.support.multidex.MultiDex;
+import android.support.test.runner.AndroidJUnitRunner;
+
+// http://stackoverflow.com/questions/32957741/android-illegalstateexception-no-instrumentation-registered-must-run-under-a-re/34590175#34590175
+public class MultiDexAndroidJUnitRunner extends AndroidJUnitRunner {
+
+    @Override
+    public void onCreate(Bundle arguments) {
+        MultiDex.install(getTargetContext());
+        super.onCreate(arguments);
+    }
+
+}

--- a/spatialconnect/src/main/AndroidManifest.xml
+++ b/spatialconnect/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
 
     <application
         android:allowBackup="true"
+        android:name="android.support.multidex.MultiDexApplication"
         android:label="@string/app_name">
 
     </application>

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/BridgeCommand.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/BridgeCommand.java
@@ -17,6 +17,8 @@ package com.boundlessgeo.spatialconnect.jsbridge;
 
 public enum BridgeCommand {
 
+    START_ALL_SERVICES(1),
+    LOAD_DEFAULT_CONFIGS(2),
     DATASERVICE_ACTIVESTORESLIST(100),
     DATASERVICE_ACTIVESTOREBYID(101),
     DATASERVICE_SPATIALQUERY(110),

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCBridge.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCBridge.java
@@ -1,0 +1,439 @@
+/**
+ * Copyright 2016 Boundless, http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License
+ */
+package com.boundlessgeo.spatialconnect.jsbridge;
+
+import android.location.Location;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.boundlessgeo.spatialconnect.SpatialConnect;
+import com.boundlessgeo.spatialconnect.geometries.SCBoundingBox;
+import com.boundlessgeo.spatialconnect.geometries.SCGeometry;
+import com.boundlessgeo.spatialconnect.geometries.SCGeometryFactory;
+import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
+import com.boundlessgeo.spatialconnect.query.SCGeometryPredicateComparison;
+import com.boundlessgeo.spatialconnect.query.SCPredicate;
+import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
+import com.boundlessgeo.spatialconnect.services.SCSensorService;
+import com.boundlessgeo.spatialconnect.stores.SCDataStore;
+import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import rx.Subscriber;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
+
+/**
+ * This module handles messages sent from Javascript.
+ */
+public class SCBridge extends ReactContextBaseJavaModule {
+
+    private static final String LOG_TAG = SCBridge.class.getSimpleName();
+    private final SpatialConnect sc;
+    private final ReactContext reactContext;
+
+    public SCBridge(ReactApplicationContext reactContext) {
+        super(reactContext);
+        // TODO: this should be a singleton with a getInstance() method or injected with dagger
+        this.sc = new SpatialConnect(reactContext.getApplicationContext());
+        this.reactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return "SCBridge";
+    }
+
+    /**
+     * Sends an event to Javascript.
+     *
+     * @param eventName the name of the event
+     * @param params    a map of the key/value pairs associated with the event
+     * @see <a href="https://facebook.github.io/react-native/docs/native-modules-android
+     * .html#sending-events-to-javascript"> https://facebook.github.io/react-native/docs/native-modules-android
+     * .html#sending-events-to-javascript</a>
+     */
+    public void sendEvent(String eventName, @Nullable WritableMap params) {
+        Log.v(LOG_TAG, String.format("Sending event %s to Javascript: %s", eventName, params.toString()));
+        this.reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(eventName, params);
+    }
+
+    /**
+     * Sends an event to Javascript.
+     *
+     * @param eventName     the name of the event
+     * @param payloadString a payload string associated with the event
+     * @see <a href="https://facebook.github.io/react-native/docs/native-modules-android
+     * .html#sending-events-to-javascript"> https://facebook.github.io/react-native/docs/native-modules-android
+     * .html#sending-events-to-javascript</a>
+     */
+    public void sendEvent(String eventName, @Nullable String payloadString) {
+        Log.v(LOG_TAG, String.format("Sending event %s to Javascript: %s", eventName, payloadString));
+        this.reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(eventName, payloadString);
+    }
+
+    /**
+     * Handles a message sent from Javascript.  Expects the message envelope to look like:
+     * <code>{"action":<integer>,"payload":<JSON Object>}</code>
+     *
+     * @param message
+     */
+    @ReactMethod
+    public void handler(ReadableMap message) {
+        Log.d(LOG_TAG, "Received message from JS: " + message.toString());
+        message = message.getMap("data");
+
+        if (message == null && message.equals("undefined")) {
+            Log.w(LOG_TAG, "data message was null or undefined");
+            return;
+        }
+        else {
+            // parse bridge message to determine command
+            Integer actionNumber = message.getInt("action");
+            BridgeCommand command = BridgeCommand.fromActionNumber(actionNumber);
+            if (command.equals(BridgeCommand.START_ALL_SERVICES)) {
+                handleStartAllServices();
+            }
+            if (command.equals(BridgeCommand.LOAD_DEFAULT_CONFIGS)) {
+                handleLoadDefaultConfigs();
+            }
+            if (command.equals(BridgeCommand.SENSORSERVICE_GPS)) {
+                handleSensorServiceGps(message);
+            }
+            if (command.equals(BridgeCommand.DATASERVICE_ACTIVESTORESLIST)) {
+                handleActiveStoresList();
+            }
+            if (command.equals(BridgeCommand.DATASERVICE_ACTIVESTOREBYID)) {
+                handleActiveStoreById(message);
+            }
+            if (command.equals(BridgeCommand.DATASERVICE_GEOSPATIALQUERYALL)
+                    || command.equals(BridgeCommand.DATASERVICE_SPATIALQUERYALL)) {
+                handleQueryAll(message);
+            }
+            if (command.equals(BridgeCommand.DATASERVICE_UPDATEFEATURE)) {
+                handleUpdateFeature(message);
+            }
+            if (command.equals(BridgeCommand.DATASERVICE_DELETEFEATURE)) {
+                handleDeleteFeature(message);
+            }
+            if (command.equals(BridgeCommand.DATASERVICE_CREATEFEATURE)) {
+                handleCreateFeature(message);
+            }
+        }
+    }
+
+
+    /**
+     * Handles the {@link BridgeCommand#START_ALL_SERVICES} command.
+     */
+    private void handleStartAllServices() {
+        Log.d(LOG_TAG, "Handling START_ALL_SERVICES message");
+        sc.startAllServices();
+    }
+
+    /**
+     * Handles the {@link BridgeCommand#LOAD_DEFAULT_CONFIGS} command.
+     */
+    private void handleLoadDefaultConfigs() {
+        Log.d(LOG_TAG, "Handling LOAD_DEFAULT_CONFIGS message");
+        sc.loadDefaultConfigs();
+    }
+
+    /**
+     * Handles all the {@link BridgeCommand#SENSORSERVICE_GPS} commands.
+     *
+     * @param message
+     */
+    private void handleSensorServiceGps(ReadableMap message) {
+        Log.d(LOG_TAG, "Handling SENSORSERVICE_GPS message :" + message.toString());
+        SCSensorService sensorService = sc.getSensorService();
+        Integer payloadNumber = message.getInt("payload");
+        if (payloadNumber == 1) {
+            sensorService.startGPSListener();
+            sensorService.getLastKnownLocation()
+                    .subscribeOn(Schedulers.newThread())
+                    .subscribe(new Action1<Location>() {
+                        @Override
+                        public void call(Location location) {
+                            WritableMap params = Arguments.createMap();
+                            params.putString("latitude", String.valueOf(location.getLatitude()));
+                            params.putString("longitude", String.valueOf(location.getLongitude()));
+                            sendEvent("lastKnownLocation", params);
+                        }
+                    });
+        }
+        if (payloadNumber == 0) {
+            sensorService.disableGPSListener();
+        }
+    }
+
+    /**
+     * Handles the {@link BridgeCommand#DATASERVICE_ACTIVESTORESLIST} command.
+     */
+    private void handleActiveStoresList() {
+        Log.d(LOG_TAG, "Handling DATASERVICE_ACTIVESTORESLIST message");
+        List<SCDataStore> stores = sc.getDataService().getActiveStores();
+        WritableMap eventPayload = Arguments.createMap();
+        WritableArray storesArray = Arguments.createArray();
+        for (SCDataStore store : stores) {
+            storesArray.pushMap(getStoreMap(store));
+        }
+        eventPayload.putArray("stores", storesArray);
+        sendEvent("storesList", eventPayload);
+    }
+
+    /**
+     * Handles all the {@link BridgeCommand#DATASERVICE_ACTIVESTOREBYID} commands.
+     *
+     * @param message
+     */
+    private void handleActiveStoreById(ReadableMap message) {
+        Log.d(LOG_TAG, "Handling ACTIVESTOREBYID message :" + message.toString());
+        String storeId = message.getMap("payload").getString("storeId");
+        SCDataStore store = sc.getDataService().getStoreById(storeId);
+        sendEvent("store", getStoreMap(store));
+    }
+
+    /**
+     * Handles the {@link BridgeCommand#DATASERVICE_GEOSPATIALQUERYALL} and
+     * {@link BridgeCommand#DATASERVICE_SPATIALQUERYALL} commands.
+     *
+     * @param message
+     */
+    private void handleQueryAll(ReadableMap message) {
+        Log.d(LOG_TAG, "Handling *QUERYALL message :" + message.toString());
+        SCQueryFilter filter = getFilter(message);
+        if (filter != null) {
+            sc.getDataService().queryAllStores(filter)
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(
+                            new Subscriber<SCSpatialFeature>() {
+                                @Override
+                                public void onCompleted() {
+                                    Log.d(LOG_TAG, "query observable completed");
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    Log.e(LOG_TAG, "onError()\n" + e.getMessage());
+                                }
+
+                                @Override
+                                public void onNext(SCSpatialFeature feature) {
+                                    try {
+                                        // base64 encode id and set it before sending across wire
+                                        String encodedId = ((SCGeometry) feature).getKey().encodedCompositeKey();
+                                        feature.setId(encodedId);
+                                        sendEvent("spatialQuery", ((SCGeometry) feature).toJson());
+                                    }
+                                    catch (UnsupportedEncodingException e) {
+                                        e.printStackTrace();
+                                    }
+                                }
+                            }
+                    );
+        }
+    }
+
+    /**
+     * Handles the {@link BridgeCommand#DATASERVICE_UPDATEFEATURE} command.
+     *
+     * @param message
+     */
+    private void handleUpdateFeature(ReadableMap message) {
+        Log.d(LOG_TAG, "Handling UPDATEFEATURE message :" + message.toString());
+        try {
+            SCSpatialFeature featureToUpdate = getFeatureToUpdate(message.getMap("payload").getString("feature"));
+            sc.getDataService().getStoreById(featureToUpdate.getKey().getStoreId())
+                    .update(featureToUpdate)
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(
+                            new Subscriber<SCSpatialFeature>() {
+                                @Override
+                                public void onCompleted() {
+                                    Log.d(LOG_TAG, "update completed");
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    Log.e(LOG_TAG, "onError()\n" + e.getLocalizedMessage());
+                                }
+
+                                @Override
+                                public void onNext(SCSpatialFeature updated) {
+                                    Log.d(LOG_TAG, "feature updated!");
+                                    //TODO: send this over some "update" stream
+                                }
+                            }
+                    );
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Handles the {@link BridgeCommand#DATASERVICE_DELETEFEATURE} command.
+     *
+     * @param message
+     */
+    private void handleDeleteFeature(ReadableMap message) {
+        Log.d(LOG_TAG, "Handling DELETEFEATURE message :" + message.toString());
+        try {
+            SCKeyTuple featureKey = new SCKeyTuple(message.getString("payload"));
+            sc.getDataService().getStoreById(featureKey.getStoreId())
+                    .delete(featureKey)
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(
+                            new Subscriber<Boolean>() {
+                                @Override
+                                public void onCompleted() {
+                                    Log.d(LOG_TAG, "delete completed");
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    Log.e(LOG_TAG, "onError()\n" + e.getLocalizedMessage());
+                                }
+
+                                @Override
+                                public void onNext(Boolean deleted) {
+                                    //TODO: send this over some "deleted" stream
+                                    Log.d(LOG_TAG, "feature deleted!");
+                                }
+                            }
+                    );
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Handles the {@link BridgeCommand#DATASERVICE_CREATEFEATURE} command.
+     *
+     * @param message
+     */
+    private void handleCreateFeature(ReadableMap message) {
+        Log.d(LOG_TAG, "Handling CREATEFEATURE message :" + message.toString());
+        try {
+            SCSpatialFeature newFeature = getNewFeature(message.getMap("payload"));
+            sc.getDataService().getStoreById(newFeature.getKey().getStoreId())
+                    .create(newFeature)
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(
+                            new Subscriber<SCSpatialFeature>() {
+                                @Override
+                                public void onCompleted() {
+                                    Log.d(LOG_TAG, "create completed");
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    e.printStackTrace();
+                                    Log.e(LOG_TAG, "onError()\n" + e.getLocalizedMessage());
+                                }
+
+                                @Override
+                                public void onNext(SCSpatialFeature feature) {
+                                    try {
+                                        // base64 encode id and set it before sending across wire
+                                        String encodedId = ((SCGeometry) feature).getKey().encodedCompositeKey();
+                                        feature.setId(encodedId);
+                                        sendEvent("createFeature", ((SCGeometry) feature).toJson());
+                                    } catch (UnsupportedEncodingException e) {
+                                        e.printStackTrace();
+                                    }
+                                }
+                            }
+                    );
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Returns an SCSpatialFeature instance based on the message from the bridge to create a new feature.
+     *
+     * @param message the message received from the Javascript
+     * @return
+     * @throws UnsupportedEncodingException
+     */
+    private SCSpatialFeature getNewFeature(ReadableMap message) throws UnsupportedEncodingException {
+        String featureString = message.getString("feature");
+        SCSpatialFeature feature = new SCGeometryFactory().getSpatialFeatureFromFeatureJson(featureString);
+        feature.setStoreId(message.getString("storeId"));
+        feature.setLayerId(message.getString("layerId"));
+        return feature;
+    }
+
+    /**
+     * Returns an SCSpatialFeature instance based on the GeoJSON Feature string sent from the bridge for update.
+     *
+     * @param featureString the GeoJSON string representing the feature
+     * @return
+     * @throws UnsupportedEncodingException
+     */
+    private SCSpatialFeature getFeatureToUpdate(String featureString) throws UnsupportedEncodingException {
+        SCSpatialFeature feature = new SCGeometryFactory().getSpatialFeatureFromFeatureJson(featureString);
+        SCKeyTuple decodedTuple = new SCKeyTuple(feature.getId());
+        // update feature with decoded values
+        feature.setStoreId(decodedTuple.getStoreId());
+        feature.setLayerId(decodedTuple.getLayerId());
+        feature.setId(decodedTuple.getFeatureId());
+        return feature;
+    }
+
+    // builds a query filter based on the filter in payload
+    private SCQueryFilter getFilter(ReadableMap message) {
+        ReadableArray extent = message.getMap("payload").getMap("filter").getArray("$geocontains");
+        SCBoundingBox bbox = new SCBoundingBox(
+                extent.getDouble(0),
+                extent.getDouble(1),
+                extent.getDouble(2),
+                extent.getDouble(3)
+        );
+        SCQueryFilter filter = new SCQueryFilter(
+                new SCPredicate(bbox, SCGeometryPredicateComparison.SCPREDICATE_OPERATOR_WITHIN)
+        );
+        return filter;
+    }
+
+    // creates a WriteableMap of the SCDataStore attributes
+    private WritableMap getStoreMap(SCDataStore store) {
+        WritableMap params = Arguments.createMap();
+        params.putString("storeId", store.getStoreId());
+        params.putString("name", store.getName());
+        params.putString("type", store.getType());
+        params.putInt("version", store.getVersion());
+        params.putString("key", store.getKey());
+        return params;
+    }
+}

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCReactPackage.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCReactPackage.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 Boundless, http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License
+ */
+package com.boundlessgeo.spatialconnect.jsbridge;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SCReactPackage implements ReactPackage {
+
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        // register module so it's available to Javascript
+        modules.add(new SCBridge(reactContext));
+        return modules;
+    }
+}
+

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/messaging/SCMessage.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/messaging/SCMessage.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Boundless, http://boundlessgeo.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License
+ */
 package com.boundlessgeo.spatialconnect.messaging;
 
 public class SCMessage {


### PR DESCRIPTION
## Status
**READY**

## Description
This adds the components needed to enable a React Native application to execute methods of the SpatialConnect Android SDK.  Also configuring library and tests for [multidex](http://developer.android.com/tools/building/multidex.html)  

## Todos
- [x] Tests
- [x] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout react-native-bridge
./gradlew connectedCheck
```

## Impacted Areas in Application

The Travis CI is affected by this PR.  See [this](boundlessgeo/spatialconnect-android-sdk/issues/66) for more details.  The tests should be run locally on an emulator that has enough disk space.

@boundlessgeo/spatial-connect
