### PR TITLE
reverting multidex dependency to 1.0.0

### DIFF
--- a/spatialconnect/build.gradle
+++ b/spatialconnect/build.gradle
@@ -67,7 +67,7 @@ repositories {
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.google.android.gms:play-services-maps:7.8.0'
-    compile 'com.android.support:multidex:1.0.1'
+    compile 'com.android.support:multidex:1.0.0'
     compile 'com.bedatadriven:jackson-datatype-jts:1.0'
     compile 'io.reactivex:rxandroid:1.1.0'
     compile 'io.reactivex:rxjava:1.1.0'


### PR DESCRIPTION
## Status
**READY**

## Description
Need to revert to 1.0.0 so `uploadArchives` gradle task is able to install aar in local maven repo.  See https://code.google.com/p/android/issues/detail?id=183349 to learn more about the issue

