### PR TITLE
only specify the root url for the remote endpoint in a config

### DIFF
--- a/spatialconnect/src/androidTest/res/raw/scconfig.json
+++ b/spatialconnect/src/androidTest/res/raw/scconfig.json
@@ -1,5 +1,5 @@
 {
-  "remote": "http://efc.boundlessgeo.com:8085/config",
+  "remote": "http://efc.boundlessgeo.com:8085/",
   "stores":[
     {
       "store_type": "geojson",

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/services/SCConfigService.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/services/SCConfigService.java
@@ -123,7 +123,8 @@ public class SCConfigService extends SCService {
         registerForms(configFiles);
         String remoteUrl = getRemoteConfigUrl(configFiles);
         if (remoteUrl != null) {
-            loadRemoteConfig(remoteUrl);
+            String configPath = remoteUrl.endsWith("/") ? "config" : "/config";
+            loadRemoteConfig(remoteUrl + configPath);
         }
     }
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
The `remote` attribute of the config between iOS and Android SDKs should be the same.  This updates the Android SDK to accommodate this parity 

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work. 

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 

@boundlessgeo/spatial-connect
