### PR TITLE
updating bridge to respond with lat/lon instead of latitude/longitude…

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCBridge.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCBridge.java
@@ -187,8 +187,8 @@ public class SCBridge extends ReactContextBaseJavaModule {
                         @Override
                         public void call(Location location) {
                             WritableMap params = Arguments.createMap();
-                            params.putString("latitude", String.valueOf(location.getLatitude()));
-                            params.putString("longitude", String.valueOf(location.getLongitude()));
+                            params.putString("lat", String.valueOf(location.getLatitude()));
+                            params.putString("lon", String.valueOf(location.getLongitude()));
                             sendEvent("lastKnownLocation", params);
                         }
                     });

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptBridgeHandler.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptBridgeHandler.java
@@ -89,8 +89,8 @@ public class SCJavascriptBridgeHandler implements WebViewJavascriptBridge.WVJBHa
                                 @Override
                                 public void call(Location location) {
                                     bridge.callHandler("lastKnownLocation",
-                                            "{\"latitude\":\"" + location.getLatitude() + "\"," +
-                                                    "\"longitude\":\"" + location.getLongitude() + "\"}");
+                                            "{\"lat\":\"" + location.getLatitude() + "\"," +
+                                                    "\"lon\":\"" + location.getLongitude() + "\"}");
                                 }
                             });
                     return;


### PR DESCRIPTION
## Status
**READY**

## Description
Updating bridge response to use the same attributes for location used by the spatialconnect-ios-sdk and spatialconnect-js

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work. 

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 

@boundlessgeo/spatial-connect
