### PR TITLE
Ios forms parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # spatialconnect-android-sdk
 SpatialConnect library for Android
 
+# Current Version
+0.3.0
+
 [![Build
 Status](https://travis-ci.org/boundlessgeo/spatialconnect-android-sdk.svg?branch=develop)](https://travis-ci.org/boundlessgeo/spatialconnect-android-sdk)
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCStoreConfig.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCStoreConfig.java
@@ -56,6 +56,12 @@ public class SCStoreConfig
      */
     private String name;
 
+    /**
+     * Optionally specify a default layer for this store
+     */
+    @JsonProperty("default_layer")
+    private String defaultLayer;
+
     public SCStoreConfig() {}
 
     public String getType()
@@ -111,5 +117,13 @@ public class SCStoreConfig
     public void setName(String name)
     {
         this.name = name;
+    }
+
+    public String getDefaultLayer() {
+        return defaultLayer;
+    }
+
+    public void setDefaultLayer(String defaultLayer) {
+        this.defaultLayer = defaultLayer;
     }
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/geometries/SCSpatialFeature.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/geometries/SCSpatialFeature.java
@@ -16,6 +16,7 @@ package com.boundlessgeo.spatialconnect.geometries;
 
 
 import com.boundlessgeo.spatialconnect.scutilities.Json.ObjectMappers;
+import com.boundlessgeo.spatialconnect.services.SCConfigService;
 import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -102,6 +103,14 @@ public class SCSpatialFeature
 
     public SCKeyTuple getKey() {
         return new SCKeyTuple(this.storeId, this.layerId, this.id);
+    }
+
+    public Map<String, Object> getMetadata() {
+        Map map = new HashMap<>(3);
+        map.put("storeId", storeId);
+        map.put("layerId", layerId);
+        map.put("client", SCConfigService.getClientId());
+        return map;
     }
 
     public String toJson() {

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/services/SCNetworkService.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/services/SCNetworkService.java
@@ -85,10 +85,8 @@ public class SCNetworkService extends SCService {
     }
 
     public String post(String url, String json) throws IOException {
-        String authString = ",\"metadata\": " + "{\"client\":\"" +  SCConfigService.getClientId() + "\"}}";
-        String jsonBody = json.substring(0, json.length()-1) + authString;
-        Log.d(LOG_TAG, "POST " + url + "\n" + jsonBody);
-        RequestBody body = RequestBody.create(JSON, jsonBody);
+        Log.d(LOG_TAG, "POST " + url + "\n" + json);
+        RequestBody body = RequestBody.create(JSON, json);
         Request request = new Request.Builder()
                 .url(url)
                 .post(body)


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-133

## Description
Bringing the form submission functionality to parity with spatialconnect-ios-sdk. This means sending the layerId and clientId in a metadata tag in the GeoJSON representation of a SCSpatialFeature

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect
