### PR TITLE
Remove android:name for RN 0.29 support

### DIFF
--- a/spatialconnect/src/main/AndroidManifest.xml
+++ b/spatialconnect/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
 
     <application
         android:allowBackup="true"
-        android:name="android.support.multidex.MultiDexApplication"
         android:label="@string/app_name">
 
     </application>


### PR DESCRIPTION
## Status
**READY**

## Description
- Problem: React Native 0.29+ applications require `android:name` in the manifest. If this library also specifices `android:name`, a manifest merge error occurs. 
- Solution: Remove android:name from the manifest. Multidex is still enabled in `build.gradle`

```sh
git fetch --all
git checkout develop
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect

