### PR TITLE
Add bindMapView method to SCBridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ build/
 
 #NDK
 obj/
+
+node_modules/

--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,8 @@ allprojects {
         maven {
             url 'https://repo.eclipse.org/content/repositories/paho-releases/'
         }
+        maven {
+            url '../node_modules/react-native/android'
+        }
     }
 }

--- a/spatialconnect/build.gradle
+++ b/spatialconnect/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     compile 'io.reactivex:rxjava:1.1.0'
     compile 'commons-io:commons-io:2.4'
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
-    compile 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:0.34.0'
     compile 'com.google.protobuf:protobuf-java:3.0.0'
     compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2'
     compile ('org.eclipse.paho:org.eclipse.paho.android.service:1.0.2') {

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/tiles/GpkgRasterSource.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/tiles/GpkgRasterSource.java
@@ -7,6 +7,7 @@ import com.boundlessgeo.spatialconnect.stores.SCRasterStore;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +40,6 @@ public class GpkgRasterSource implements SCRasterStore {
 
     @Override
     public List<SCGpkgTileSource> rasterList() {
-        return (List) ((GeoPackageAdapter) gpkgStore.getAdapter()).getTileSources().values();
+        return new ArrayList<SCGpkgTileSource>(((GeoPackageAdapter)gpkgStore.getAdapter()).getTileSources().values());
     }
 }


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-228

## Description
- Adds bindMapView method to SCBridge. Currently adds all raster layers from all stores to the map
- Updates the react native dependency. react-native must now be installed in the root directory from npm. This allows the sdk to use the latest version of react-native

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect

