### PR TITLE
Store vector layers and raster layers

### DIFF
--- a/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/GeoJsonTest.java
+++ b/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/GeoJsonTest.java
@@ -26,6 +26,7 @@ import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
 import com.boundlessgeo.spatialconnect.scutilities.HttpHandler;
 import com.boundlessgeo.spatialconnect.stores.SCDataStore;
 import com.boundlessgeo.spatialconnect.stores.SCDataStoreStatus;
+import com.boundlessgeo.spatialconnect.stores.SCSpatialStore;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -85,7 +86,7 @@ public class GeoJsonTest extends BaseTestCase {
                 new SCPredicate(bbox, SCGeometryPredicateComparison.SCPREDICATE_OPERATOR_WITHIN)
         );
         TestSubscriber testSubscriber = new TestSubscriber();
-        geoJsonStore.query(filter).subscribe(testSubscriber);
+        ((SCSpatialStore) geoJsonStore).query(filter).subscribe(testSubscriber);
         testSubscriber.awaitTerminalEvent();
         testSubscriber.assertCompleted();
         testSubscriber.assertNoErrors();

--- a/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/GeoPackageTest.java
+++ b/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/GeoPackageTest.java
@@ -34,6 +34,7 @@ import com.boundlessgeo.spatialconnect.stores.SCDataStore;
 import com.boundlessgeo.spatialconnect.stores.SCDataStoreException;
 import com.boundlessgeo.spatialconnect.stores.SCDataStoreStatus;
 import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
+import com.boundlessgeo.spatialconnect.stores.SCSpatialStore;
 import com.boundlessgeo.spatialconnect.stores.SCStoreStatusEvent;
 import com.squareup.sqlbrite.BriteDatabase;
 import com.vividsolutions.jts.geom.Geometry;
@@ -107,7 +108,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageQueryWithin() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
 
         SCQueryFilter filter = new SCQueryFilter(
                 new SCPredicate(HAITI_BOUNDING_BOX, SCGeometryPredicateComparison.SCPREDICATE_OPERATOR_WITHIN)
@@ -142,7 +143,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageQueryContains() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
 
         SCQueryFilter filter = new SCQueryFilter(
                 new SCPredicate(HAITI_BOUNDING_BOX, SCGeometryPredicateComparison.SCPREDICATE_OPERATOR_WITHIN)
@@ -175,7 +176,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageQueryById() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         SCKeyTuple featureKey = new SCKeyTuple(HAITI_GPKG_ID, "point_features", "1");
         TestSubscriber testSubscriber = new TestSubscriber();
         gpkgStore.queryById(featureKey).timeout(10, TimeUnit.SECONDS).subscribe(testSubscriber);
@@ -193,7 +194,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageCreateFeature() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         SCSpatialFeature newFeature = getTestHaitiPoint();
         // remove the feature id b/c we want the db to create that for us
         newFeature.setId("");
@@ -217,7 +218,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageUpdateFeature() {
-        final SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        final SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         final SCSpatialFeature pointToUpdate = getTestHaitiPoint();
         TestSubscriber testSubscriber = new TestSubscriber();
         gpkgStore.update(pointToUpdate).subscribe(testSubscriber);
@@ -237,7 +238,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageDeleteFeature() {
-        final SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        final SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         final SCSpatialFeature pointToDelete = getTestLinearFeatureHaitiPoint();
         TestSubscriber testSubscriber = new TestSubscriber();
         gpkgStore.delete(pointToDelete.getKey()).subscribe(testSubscriber);
@@ -254,7 +255,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageCreateFeatureThrowsDataStoreExceptionWhenNoFeatureTablesExist() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         TestSubscriber testSubscriber = new TestSubscriber();
         SCSpatialFeature feature = getTestHaitiPoint();
         feature.setLayerId("invalid_table_name");
@@ -268,7 +269,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageUpdateFeatureThrowsDataStoreExceptionWhenNoFeatureTablesExist() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         TestSubscriber testSubscriber = new TestSubscriber();
         SCSpatialFeature feature = getTestHaitiPoint();
         feature.setLayerId("invalid_table_name");
@@ -283,7 +284,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageDeleteFeatureThrowsDataStoreExceptionWhenNoFeatureTablesExist() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         TestSubscriber testSubscriber = new TestSubscriber();
         SCSpatialFeature feature = getTestHaitiPoint();
         feature.setLayerId("invalid_table_name");
@@ -297,7 +298,7 @@ public class GeoPackageTest extends BaseTestCase {
 
     @Test
     public void testGeoPackageQueryByIdThrowsDataStoreExceptionWhenNoFeatureTablesExist() {
-        SCDataStore gpkgStore = sc.getDataService().getStoreById(HAITI_GPKG_ID);
+        SCSpatialStore gpkgStore = ((SCSpatialStore) sc.getDataService().getStoreById(HAITI_GPKG_ID));
         TestSubscriber testSubscriber = new TestSubscriber();
         SCSpatialFeature feature = getTestHaitiPoint();
         feature.setLayerId("invalid_table_name");

--- a/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/WFSStoreTest.java
+++ b/spatialconnect/src/androidTest/java/com/boundlessgeo/spatialconnect/test/WFSStoreTest.java
@@ -65,7 +65,7 @@ public class WFSStoreTest extends BaseTestCase {
     public void testLayerNamesAreParsedFromCapabilities() {
         WFSStore store = (WFSStore) sc.getDataService().getStoreById(WFS_STORE_ID);
         assertTrue("There should be multiple layers.",
-                store.getLayerNames().size() > 0
+                store.layers().size() > 0
         );
     }
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/dataAdapter/GeoJsonAdapter.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/dataAdapter/GeoJsonAdapter.java
@@ -35,6 +35,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 
 import okhttp3.Response;
 import rx.Observable;
@@ -208,6 +210,10 @@ public class GeoJsonAdapter extends SCDataAdapter {
 
     public void delete(String featureId) {
 
+    }
+
+    public List<String> layers() {
+        return Arrays.asList(DEFAULTLAYER);
     }
 
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/dataAdapter/GeoPackageAdapter.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/dataAdapter/GeoPackageAdapter.java
@@ -53,6 +53,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -357,6 +358,13 @@ public class GeoPackageAdapter extends SCDataAdapter {
                 @Override
                 public void call(Subscriber<? super SCSpatialFeature> subscriber) {
                     try {
+                        Set<String> columns = featureSource.getColumns().keySet();
+                        Map<String, Object> props = new HashMap<>();
+                        for (String col : columns) {
+                            if (!col.equals(featureSource.getGeomColumnName()) && !col.equals(featureSource.getPrimaryKeyName())) {
+                                props.put(col, null);
+                            }
+                        }
                         gpkg.executeAndTrigger(tableName,
                                 String.format("INSERT OR REPLACE INTO %s (%s) VALUES (%s)",
                                         tableName,

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptBridgeHandler.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptBridgeHandler.java
@@ -29,6 +29,7 @@ import com.boundlessgeo.spatialconnect.services.SCSensorService;
 import com.boundlessgeo.spatialconnect.SpatialConnect;
 import com.boundlessgeo.spatialconnect.stores.SCDataStore;
 import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
+import com.boundlessgeo.spatialconnect.stores.SCSpatialStore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -168,8 +169,8 @@ public class SCJavascriptBridgeHandler implements WebViewJavascriptBridge.WVJBHa
                 SCSpatialFeature featureToUpdate = getFeatureToUpdate(
                   bridgeMessage.get("payload").get("feature").asText()
                 );
-                manager.getDataService().getStoreById(featureToUpdate.getKey().getStoreId())
-                  .update(featureToUpdate)
+                SCDataStore store = manager.getDataService().getStoreById(featureToUpdate.getKey().getStoreId());
+                  ((SCSpatialStore) store).update(featureToUpdate)
                   .subscribeOn(Schedulers.io())
                   .subscribe(
                     new Subscriber<Boolean>() {
@@ -197,8 +198,8 @@ public class SCJavascriptBridgeHandler implements WebViewJavascriptBridge.WVJBHa
             if (command.equals(SCCommand.DATASERVICE_DELETEFEATURE)) {
               try {
                 SCKeyTuple featureKey = new SCKeyTuple(bridgeMessage.get("payload").asText());
-                manager.getDataService().getStoreById(featureKey.getStoreId())
-                  .delete(featureKey)
+                SCDataStore store = manager.getDataService().getStoreById(featureKey.getStoreId());
+                  ((SCSpatialStore) store).delete(featureKey)
                   .subscribeOn(Schedulers.io())
                   .subscribe(
                     new Subscriber<Boolean>() {
@@ -226,8 +227,8 @@ public class SCJavascriptBridgeHandler implements WebViewJavascriptBridge.WVJBHa
             if (command.equals(SCCommand.DATASERVICE_CREATEFEATURE)) {
               try {
                 SCSpatialFeature newFeature = getNewFeature(bridgeMessage.get("payload"));
-                manager.getDataService().getStoreById(newFeature.getKey().getStoreId())
-                  .create(newFeature)
+                SCDataStore store = manager.getDataService().getStoreById(newFeature.getKey().getStoreId());
+                  ((SCSpatialStore) store).create(newFeature)
                   .subscribeOn(Schedulers.io())
                   .subscribe(
                     new Subscriber<SCSpatialFeature>() {

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/services/SCDataService.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/services/SCDataService.java
@@ -27,7 +27,9 @@ import com.boundlessgeo.spatialconnect.stores.GeoJsonStore;
 import com.boundlessgeo.spatialconnect.stores.GeoPackageStore;
 import com.boundlessgeo.spatialconnect.stores.LocationStore;
 import com.boundlessgeo.spatialconnect.stores.SCDataStore;
+import com.boundlessgeo.spatialconnect.stores.SCDataStoreLifeCycle;
 import com.boundlessgeo.spatialconnect.stores.SCDataStoreStatus;
+import com.boundlessgeo.spatialconnect.stores.SCSpatialStore;
 import com.boundlessgeo.spatialconnect.stores.SCStoreStatusEvent;
 import com.boundlessgeo.spatialconnect.stores.WFSStore;
 
@@ -187,7 +189,7 @@ public class SCDataService extends SCService {
     public void startStore(final SCDataStore store) {
         if (!store.getStatus().equals(SCDataStoreStatus.SC_DATA_STORE_RUNNING)) {
             Log.d(LOG_TAG, "Starting store " + store.getName() + " " + store.getStoreId());
-            store.start()
+            ((SCDataStoreLifeCycle) store).start()
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(new Action1<SCStoreStatusEvent>() {
                 @Override
@@ -219,7 +221,7 @@ public class SCDataService extends SCService {
     public void stopStore(final SCDataStore store) {
         if (store.getStatus().equals(SCDataStoreStatus.SC_DATA_STORE_RUNNING)) {
             Log.d(LOG_TAG, "Stopping store " + store.getName() + " " + store.getStoreId());
-            store.stop();
+            ((SCDataStoreLifeCycle) store).stop();
             storeEventSubject.onNext(
                     new SCStoreStatusEvent(SCDataStoreStatus.SC_DATA_STORE_STOPPED, store.getStoreId()));
             if (stores.size() > 0) {
@@ -284,7 +286,7 @@ public class SCDataService extends SCService {
         if (registerStoreByConfig(config)) {
             SCDataStore store = stores.get(config.getUniqueID());
             if (store != null) {
-                store.start();
+                ((SCDataStoreLifeCycle) store).start();
             }
         }
     }
@@ -454,7 +456,7 @@ public class SCDataService extends SCService {
                     @Override
                     public Observable<SCSpatialFeature> call(SCDataStore scDataStore) {
                         Log.d(LOG_TAG, "Querying store " + scDataStore.getName());
-                        return scDataStore.query(filter);
+                        return ((SCSpatialStore) scDataStore).query(filter);
                     }
                 });
     }
@@ -465,7 +467,7 @@ public class SCDataService extends SCService {
                     @Override
                     public Observable<SCSpatialFeature> call(SCDataStore scDataStore) {
                         Log.d(LOG_TAG, "Querying store " + scDataStore.getName());
-                        return scDataStore.query(filter);
+                        return ((SCSpatialStore) scDataStore).query(filter);
                     }
                 });
     }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoJsonStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoJsonStore.java
@@ -42,10 +42,6 @@ public class GeoJsonStore extends SCDataStore implements SCSpatialStore, SCDataS
         this.setAdapter(new GeoJsonAdapter(context, scStoreConfig));
     }
 
-    public List<String> defaultLayers() {
-        return null;
-    }
-
     public List<String> layers() {
         return this.vectorLayers();
     }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoJsonStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoJsonStore.java
@@ -24,10 +24,12 @@ import com.boundlessgeo.spatialconnect.dataAdapter.SCDataAdapterStatus;
 import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
 import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
 
+import java.util.List;
+
 import rx.Observable;
 import rx.Subscriber;
 
-public class GeoJsonStore extends SCDataStore implements  SCSpatialStore, SCDataStoreLifeCycle {
+public class GeoJsonStore extends SCDataStore implements SCSpatialStore, SCDataStoreLifeCycle {
 
     private static final String LOG_TAG = GeoJsonStore.class.getSimpleName();
     public static final String TYPE = "geojson";
@@ -40,6 +42,18 @@ public class GeoJsonStore extends SCDataStore implements  SCSpatialStore, SCData
         this.setAdapter(new GeoJsonAdapter(context, scStoreConfig));
     }
 
+    public List<String> defaultLayers() {
+        return null;
+    }
+
+    public List<String> layers() {
+        return this.vectorLayers();
+    }
+
+    public List<String> vectorLayers() {
+        GeoJsonAdapter geoJsonAdapter = (GeoJsonAdapter) this.getAdapter();
+        return geoJsonAdapter.layers();
+    }
 
     @Override
     public Observable<SCSpatialFeature> query(SCQueryFilter scFilter) {

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import com.boundlessgeo.spatialconnect.config.SCStoreConfig;
 import com.boundlessgeo.spatialconnect.dataAdapter.GeoPackageAdapter;
 import com.boundlessgeo.spatialconnect.dataAdapter.SCDataAdapterStatus;
+import com.boundlessgeo.spatialconnect.db.SCGpkgFeatureSource;
 import com.boundlessgeo.spatialconnect.geometries.SCPolygon;
 import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
 import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
@@ -28,6 +29,7 @@ import com.google.android.gms.maps.GoogleMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -57,6 +59,30 @@ public class GeoPackageStore extends SCDataStore implements SCSpatialStore, SCDa
         this.setAdapter(new GeoPackageAdapter(context, scStoreConfig));
     }
 
+    public List<String> defaultLayers() {
+        return null;
+    }
+
+    public List<String> layers() {
+        List<String> allLayers = new ArrayList<String>();
+        allLayers.addAll(this.vectorLayers());
+        allLayers.addAll(this.rasterLayers());
+        return allLayers;
+    }
+
+    public List<String> vectorLayers() {
+        GeoPackageAdapter adapter = (GeoPackageAdapter) this.getAdapter();
+        Map<String, SCGpkgFeatureSource> fs =  adapter.getFeatureSources();
+        List<String> layerNames = new ArrayList<>(fs.keySet());
+        return layerNames;
+    }
+
+    public List<String> rasterLayers() {
+        GeoPackageAdapter adapter = (GeoPackageAdapter) this.getAdapter();
+        Map<String, SCGpkgTileSource> fs =  adapter.getTileSources();
+        List<String> layerNames = new ArrayList<>(fs.keySet());
+        return layerNames;
+    }
 
     public void addLayer(String layer, Map<String,String>  fields) {
         ((GeoPackageAdapter) getAdapter()).addLayer(layer, fields);
@@ -158,8 +184,4 @@ public class GeoPackageStore extends SCDataStore implements SCSpatialStore, SCDa
         return null;
     }
 
-    @Override
-    public List<SCGpkgTileSource> rasterList() {
-        return null;
-    }
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
@@ -59,10 +59,6 @@ public class GeoPackageStore extends SCDataStore implements SCSpatialStore, SCDa
         this.setAdapter(new GeoPackageAdapter(context, scStoreConfig));
     }
 
-    public List<String> defaultLayers() {
-        return null;
-    }
-
     public List<String> layers() {
         List<String> allLayers = new ArrayList<String>();
         allLayers.addAll(this.vectorLayers());

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCDataStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCDataStore.java
@@ -34,7 +34,7 @@ import java.util.UUID;
  * Some implementations may throw {@link SCDataStoreException} if a problem arises that the client cannot recover from.
  * For example, trying to write to a table that doesn't exist will throw a {@link SCDataStoreException}.
  */
-public abstract class SCDataStore implements SCSpatialStore {
+public abstract class SCDataStore {
 
     private SCDataAdapter adapter;
     private String storeId;
@@ -43,7 +43,6 @@ public abstract class SCDataStore implements SCSpatialStore {
     private String type;
     private Context context;
     private SCDataStoreStatus status = SCDataStoreStatus.SC_DATA_STORE_STOPPED;
-    private List<String> defaultLayers;
 
     public SCDataStore(Context context, SCStoreConfig scStoreConfig) {
         this.context = context;
@@ -115,12 +114,8 @@ public abstract class SCDataStore implements SCSpatialStore {
         this.status = status;
     }
 
-    public List<String> getDefaultLayers() {
-        return defaultLayers;
-    }
-
-    public void setDefaultLayers(List<String> defaultLayers) {
-        this.defaultLayers = defaultLayers;
+    public List<String> layers() {
+        return null;
     }
 
     public String versionKey() {
@@ -134,7 +129,6 @@ public abstract class SCDataStore implements SCSpatialStore {
         storeMap.put("type", this.type);
         storeMap.put("version", this.version);
         storeMap.put("key", getKey());
-        storeMap.put("defaultLayers", TextUtils.join(",", getDefaultLayers()));
         return storeMap;
     }
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCRasterStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCRasterStore.java
@@ -11,5 +11,5 @@ public interface SCRasterStore {
 
     void overlayFromLayer(String layerName, GoogleMap map);
     SCPolygon getCoverage();
-    List<SCGpkgTileSource> rasterList();
+    List<String> rasterLayers();
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCSpatialStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCSpatialStore.java
@@ -17,16 +17,22 @@ package com.boundlessgeo.spatialconnect.stores;
 
 import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
 import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
+
+import java.util.List;
+
 import rx.Observable;
 
 /**
  * Interface definition for the spatial store.
  */
-public interface SCSpatialStore extends SCDataStoreLifeCycle
+public interface SCSpatialStore
 {
     Observable query(SCQueryFilter scFilter);
     Observable queryById(SCKeyTuple keyTuple);
     Observable create(SCSpatialFeature scSpatialFeature);
     Observable update(SCSpatialFeature scSpatialFeature);
     Observable delete(SCKeyTuple keyTuple);
+    List<String> vectorLayers();
+    List<String> defaultLayers();
+
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCSpatialStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCSpatialStore.java
@@ -33,6 +33,4 @@ public interface SCSpatialStore
     Observable update(SCSpatialFeature scSpatialFeature);
     Observable delete(SCKeyTuple keyTuple);
     List<String> vectorLayers();
-    List<String> defaultLayers();
-
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/WFSStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/WFSStore.java
@@ -51,6 +51,7 @@ public class WFSStore extends SCDataStore implements  SCSpatialStore, SCDataStor
     private static final String LOG_TAG = WFSStore.class.getSimpleName();
     private String baseUrl;
     private List<String> layerNames;
+    private List<String> defaultLayers;
     public static final String TYPE = "wfs";
 
     public WFSStore(Context context, SCStoreConfig scStoreConfig) {
@@ -65,12 +66,24 @@ public class WFSStore extends SCDataStore implements  SCSpatialStore, SCDataStor
         }
     }
 
+    public List<String> defaultLayers() {
+        return this.defaultLayers;
+    }
+
+    public List<String> layers() {
+        return this.vectorLayers();
+    }
+
+    public List<String> vectorLayers() {
+        return this.layerNames;
+    }
+
     @Override
     public Observable<SCSpatialFeature> query(SCQueryFilter scFilter) {
         // if there are no layer names supplied in the query filter, then search only on the default layers
         final List<String> layerNames = scFilter.getLayerIds().size() > 0 ?
                 scFilter.getLayerIds() :
-                getDefaultLayers();
+                defaultLayers();
 
         // TODO: when implmenting version 2.0.0, "maxFeatures" has been changed to "count"
         // see: http://docs.geoserver.org/latest/en/user/services/wfs/reference.html#getfeature
@@ -236,6 +249,11 @@ public class WFSStore extends SCDataStore implements  SCSpatialStore, SCDataStor
         return entries;
     }
 
+
+    private void setDefaultLayers(List<String> defaultLayers) {
+        this.defaultLayers = defaultLayers;
+    }
+
     private String readFeatureType(XmlPullParser parser) throws XmlPullParserException, IOException {
         parser.require(XmlPullParser.START_TAG, null, "FeatureType");
         String layerName = null;
@@ -311,8 +329,4 @@ public class WFSStore extends SCDataStore implements  SCSpatialStore, SCDataStor
         );
     }
 
-
-    public List<String> getLayerNames() {
-        return layerNames;
-    }
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/tiles/GpkgRasterSource.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/tiles/GpkgRasterSource.java
@@ -39,7 +39,7 @@ public class GpkgRasterSource implements SCRasterStore {
     }
 
     @Override
-    public List<SCGpkgTileSource> rasterList() {
-        return new ArrayList<SCGpkgTileSource>(((GeoPackageAdapter)gpkgStore.getAdapter()).getTileSources().values());
+    public List<String> rasterLayers() {
+        return gpkgStore.rasterLayers();
     }
 }


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-292

## Description
- SCDataStore no longer implements SCSpatialStore
- SCDataStore has `layers` method
- SCSpatialStore has `defaultLayers` and `vectorLayers`
- SCRasterStore has `rasterLayers`
- SCBridge `getStoreMap` adds vector and raster layers

## Todos
- [x] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce

```sh
git fetch --all
git checkout <feature_branch> 
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect

