### PR TITLE
out of memory error fix for download status

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/HttpHandler.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/HttpHandler.java
@@ -111,6 +111,7 @@ public class HttpHandler {
                         if (totalSinceLastPublish > (contentLength / 16)) {
                             totalSinceLastPublish = 0;
                             subscriber.onNext((float) progress / 100);
+                            sink.emitCompleteSegments();
                         }
                     }
                     sink.writeAll(source);


### PR DESCRIPTION
## Status
Ready

## Description
Fixed out of memory errors when sending download progress

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

```sh
git fetch --all
git checkout <feature_branch> 
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect

