### PR TITLE
Add addRasterLayers method to bridge

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/GeoPackageStore.java
@@ -31,6 +31,7 @@ import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
 import com.boundlessgeo.spatialconnect.tiles.GpkgTileProvider;
 import com.boundlessgeo.spatialconnect.tiles.SCGpkgTileSource;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 import com.squareup.sqlbrite.BriteDatabase;
 import com.squareup.sqlbrite.SqlBrite;
@@ -475,17 +476,16 @@ public class GeoPackageStore extends SCDataStore implements SCSpatialStore, SCDa
     }
 
     @Override
-    public void overlayFromLayer(String layer, GoogleMap map) {
+    public TileOverlay overlayFromLayer(String layer, GoogleMap map) {
         Map<String, SCGpkgTileSource> tileSources = getTileSources();
-        if (tileSources.size() > 0) {
-            if (tileSources.keySet().contains(layer)) {
-                map.addTileOverlay(
-                        new TileOverlayOptions().tileProvider(
-                                new GpkgTileProvider(tileSources.get(layer))
-                        )
-                );
-            }
+        if (tileSources.size() > 0 && tileSources.keySet().contains(layer)) {
+            return map.addTileOverlay(
+                    new TileOverlayOptions().tileProvider(
+                            new GpkgTileProvider(tileSources.get(layer))
+                    )
+            );
         }
+        return null;
     }
 
     @Override

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCRasterStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCRasterStore.java
@@ -3,13 +3,14 @@ package com.boundlessgeo.spatialconnect.stores;
 import com.boundlessgeo.spatialconnect.geometries.SCPolygon;
 import com.boundlessgeo.spatialconnect.tiles.SCGpkgTileSource;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 
 import java.util.List;
 
 public interface SCRasterStore {
 
-    void overlayFromLayer(String layerName, GoogleMap map);
+    TileOverlay overlayFromLayer(String layerName, GoogleMap map);
     SCPolygon getCoverage();
     List<String> rasterLayers();
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/tiles/GpkgRasterSource.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/tiles/GpkgRasterSource.java
@@ -4,6 +4,7 @@ import com.boundlessgeo.spatialconnect.geometries.SCPolygon;
 import com.boundlessgeo.spatialconnect.stores.GeoPackageStore;
 import com.boundlessgeo.spatialconnect.stores.SCRasterStore;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 
 import java.util.List;
@@ -18,17 +19,16 @@ public class GpkgRasterSource implements SCRasterStore {
     }
 
     @Override
-    public void overlayFromLayer(String layerName, GoogleMap map) {
+    public TileOverlay overlayFromLayer(String layer, GoogleMap map) {
         Map<String, SCGpkgTileSource> tileSources = gpkgStore.getTileSources();
-        if (tileSources.size() > 0) {
-            if (tileSources.keySet().contains(layerName)) {
-                 map.addTileOverlay(
-                         new TileOverlayOptions().tileProvider(
-                                 new GpkgTileProvider(tileSources.get(layerName))
-                         )
-                 );
-            }
+        if (tileSources.size() > 0 && tileSources.keySet().contains(layer)) {
+            return map.addTileOverlay(
+                    new TileOverlayOptions().tileProvider(
+                            new GpkgTileProvider(tileSources.get(layer))
+                    )
+            );
         }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
SPACON-410

## Description
- `bindMapView` now saves reference to the google map
- `addRasterLayers` takes an array of store ids, and adds all raster layers in those stores to the map, and removes overlays from stores not in that array
- `overlayFromLayer` now returns TileOverlay, so that it can be saved and used to remove the overlay

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] License

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect
