### PR TITLE
leave FormField as json object

### DIFF
--- a/spatialconnect/build.gradle
+++ b/spatialconnect/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven'
 
 group 'com.boundlessgeo.spatialconnect'
-version '0.11.2'
+version '0.11.3'
 
 ext {
     bintrayRepo = 'mobile'
@@ -20,7 +20,7 @@ ext {
     siteUrl = 'https://github.com/boundlessgeo/spatialconnect-android-sdk'
     gitUrl = 'https://github.com/boundlessgeo/spatialconnect-android-sdk.git'
 
-    libraryVersion = '0.11.2'
+    libraryVersion = '0.11.3'
 
     developerId = 'boundlessgeo'
     developerName = 'Mobile Boundless'
@@ -41,7 +41,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
-        versionName "0.11.2"
+        versionName "0.11.3"
         multiDexEnabled = true
         // http://developer.android.com/tools/building/multidex.html#testing
         testInstrumentationRunner "com.boundlessgeo.spatialconnect.test.MultiDexAndroidJUnitRunner"

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
@@ -1,6 +1,7 @@
 package com.boundlessgeo.spatialconnect.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class SCFormConfig {
      * List of the form fields that define this form.
      */
     @JsonProperty("fields")
-    private List<SCFormField> fields;
+    private List<JsonNode> fields;
 
     /**
      * Unique id of the team to which this form belongs.
@@ -56,11 +57,11 @@ public class SCFormConfig {
         this.id = id;
     }
 
-    public List<SCFormField> getFields() {
+    public List<JsonNode> getFields() {
         return fields;
     }
 
-    public void setFields(List<SCFormField> fields) {
+    public void setFields(List<JsonNode> fields) {
         this.fields = fields;
     }
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormField.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormField.java
@@ -1,246 +1,31 @@
 package com.boundlessgeo.spatialconnect.config;
 
+import android.text.TextUtils;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.boundlessgeo.spatialconnect.scutilities.Json.JsonUtilities;
+import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.List;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown=true)
 public class SCFormField {
 
-    /**
-     * Unique id of the form.
-     */
-    private String id;
+    public static final String FIELD_KEY = "field_key";
 
-    /**
-     * Name for the field that can be used as a column name.
-     */
-    @JsonProperty("field_key")
-    private String key;
+    private static final String TYPE = "type";
 
-    /**
-     * A label used for the display name of this field.
-     */
-    @JsonProperty("field_label")
-    private String label;
+    private static final String IS_INTEGER = "is_integer";
 
-    /**
-     * Boolean indicating if the field is required.
-     */
-    @JsonProperty("is_required")
-    private Boolean isRequired;
+    public static String getColumnType(JsonNode field) {
+        String type = JsonUtilities.getString(field, TYPE);
 
-    /**
-     * An integer representing where the field should appear in the form.
-     */
-    private Integer position;
+        if (TextUtils.isEmpty(type)) {
+            return "NULL";
+        }
 
-    /**
-     * The type of this field.
-     */
-    private String type;
-
-    /**
-     * An initial value to be set for this field.
-     */
-    @JsonProperty("initial_value")
-    private Object initialValue;
-
-    /**
-     * An minimum value for this field.
-     */
-    private Object minimum;
-
-    /**
-     * An maximum value for this field.
-     */
-    private Object maximum;
-
-    /**
-     * A boolean indicating if minimum is the exclusive minimum value for this field.
-     * @see <a href="https://github.com/json-schema/json-schema/wiki/Minimum-and-exclusiveminimum">
-     *     https://github.com/json-schema/json-schema/wiki/Minimum-and-exclusiveminimum</a>
-     */
-    @JsonProperty("exclusive_minimum")
-    private Boolean exclusiveMinimum;
-
-    /**
-     * A boolean indicating if maximum is the exclusive maximum value for this field.
-     * @see <a href="https://github.com/json-schema/json-schema/wiki/Minimum-and-exclusiveminimum">
-     *     https://github.com/json-schema/json-schema/wiki/Minimum-and-exclusiveminimum</a>
-     */
-    @JsonProperty("exclusive_maximum")
-    private Boolean exclusiveMaximum;
-
-    /**
-     * Boolean indicating if the field must be an integer.  The field must already be of type {@code numeric}
-     */
-    @JsonProperty("is_integer")
-    private Boolean isInteger = false;
-
-    /**
-     * An minimum length for this field.
-     */
-    @JsonProperty("minimum_length")
-    private Integer minimumLength;
-
-    /**
-     * An maximum length for this field.
-     */
-    @JsonProperty("maximum_length")
-    private Integer maximumLength;
-
-    /**
-     * A regex pattern that the field must match.
-     */
-    private String pattern;
-
-    /**
-     * A list of all possible valid values for this field.
-     */
-    private List<String> options;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public void setLabel(String label) {
-        this.label = label;
-    }
-
-    public Boolean isRequired() {
-        return isRequired;
-    }
-
-    public void setIsRequired(Boolean isRequired) {
-        this.isRequired = isRequired;
-    }
-
-    public Integer getPosition() {
-        return position;
-    }
-
-    public void setPosition(Integer position) {
-        this.position = position;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public Object getInitialValue() {
-        return initialValue;
-    }
-
-    public void setInitialValue(Object initialValue) {
-        this.initialValue = initialValue;
-    }
-
-    public Object getMinimum() {
-        return minimum;
-    }
-
-    public void setMinimum(Object minimum) {
-        this.minimum = minimum;
-    }
-
-    public Object getMaximum() {
-        return maximum;
-    }
-
-    public void setMaximum(Object maximum) {
-        this.maximum = maximum;
-    }
-
-    public Boolean isInteger() {
-        return isInteger;
-    }
-
-    public void setIsInteger(Boolean isInteger) {
-        this.isInteger = isInteger;
-    }
-
-    public Integer getMinimumLength() {
-        return minimumLength;
-    }
-
-    public void setMinimumLength(Integer minimumLength) {
-        this.minimumLength = minimumLength;
-    }
-
-    public Integer getMaximumLength() {
-        return maximumLength;
-    }
-
-    public void setMaximumLength(Integer maximumLength) {
-        this.maximumLength = maximumLength;
-    }
-
-    public String getPattern() {
-        return pattern;
-    }
-
-    public void setPattern(String pattern) {
-        this.pattern = pattern;
-    }
-
-    public Boolean isExclusiveMinimum() {
-        return exclusiveMinimum;
-    }
-
-    public void setExclusiveMinimum(Boolean exclusiveMinimum) {
-        this.exclusiveMinimum = exclusiveMinimum;
-    }
-
-    public Boolean isExclusiveMaximum() {
-        return exclusiveMaximum;
-    }
-
-    public void setExclusiveMaximum(Boolean exclusiveMaximum) {
-        this.exclusiveMaximum = exclusiveMaximum;
-    }
-
-    public List<String> getOptions() {
-        return options;
-    }
-
-    public void setOptions(List<String> options) {
-        this.options = options;
-    }
-
-    public String getColumnType() {
-        switch (this.type) {
+        switch (type) {
             case "string":
                 return "TEXT";
             case "number":
-                if (isInteger) {
-                    return "INTEGER";
-                }
-                return "REAL";
+                return field.get(IS_INTEGER) != null && field.get(IS_INTEGER).asBoolean() ?
+                        "INTEGER" : "REAL";
             case "boolean":
                 return "INTEGER";
             case "date":

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/Json/JsonUtilities.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/Json/JsonUtilities.java
@@ -32,6 +32,15 @@ import java.util.Map;
 
 public class JsonUtilities
 {
+
+    public static String getString(JsonNode json, String name) {
+        return getString(json, name, null);
+    }
+
+    public static String getString(JsonNode json, String name, String fallback) {
+        return json.has(name) ? json.get(name).asText() : fallback;
+    }
+
     private final String TAG = "JsonUtilities";
 
     public JsonUtilities()

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java
@@ -17,13 +17,16 @@
 package com.boundlessgeo.spatialconnect.stores;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.boundlessgeo.spatialconnect.config.SCFormConfig;
 import com.boundlessgeo.spatialconnect.config.SCFormField;
 import com.boundlessgeo.spatialconnect.config.SCStoreConfig;
 import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
+import com.boundlessgeo.spatialconnect.scutilities.Json.JsonUtilities;
 import com.boundlessgeo.spatialconnect.style.SCStyle;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -127,10 +130,12 @@ public class FormStore extends GeoPackageStore implements ISCSpatialStore, SCDat
 
     private void addLayerByConfig(SCFormConfig config) {
         boolean fieldsValid = true;
+
         Map<String, String> typeDefs = new HashMap<>();
-        for (SCFormField field : config.getFields()) {
-            if (field.getKey() != null && field.getKey().length() > 0) {
-                typeDefs.put(field.getKey(), field.getColumnType());
+        for (JsonNode field : config.getFields()) {
+            String fieldKey = JsonUtilities.getString(field, SCFormField.FIELD_KEY);
+            if (!TextUtils.isEmpty(fieldKey)) {
+                typeDefs.put(fieldKey, SCFormField.getColumnType(field));
             } else {
                 fieldsValid = false;
                 break;


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
UMC-25

## Description
This is part of the way there towards matching the behavior of the iOS SDK where form fields are just left as dictionaries. We ran into an issue where form fields weren't accurately represented in the javascript on Android. This is because the FormField POJO in the Android SDK wasn't up to date.

Down the road, we'd like to change this to a HashMap (instead of JsonNode), but that will require upgrading React-Native to 0.46

## Todos

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git fetch --all
git checkout <feature_branch> 
./gradlew connectedCheck
```

@boundlessgeo/spatial-connect
