### PR TITLE
Moving jsbridge code to the sdk

### DIFF
--- a/spatialconnect/build.gradle
+++ b/spatialconnect/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven'
 
 group 'com.boundlessgeo.spatialconnect'
-version '0.11.4'
+version '0.11.5'
 
 ext {
     bintrayRepo = 'mobile'
@@ -20,7 +20,7 @@ ext {
     siteUrl = 'https://github.com/boundlessgeo/spatialconnect-android-sdk'
     gitUrl = 'https://github.com/boundlessgeo/spatialconnect-android-sdk.git'
 
-    libraryVersion = '0.11.4'
+    libraryVersion = '0.11.5'
 
     developerId = 'boundlessgeo'
     developerName = 'Mobile Boundless'
@@ -41,7 +41,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
-        versionName "0.11.4"
+        versionName "0.11.5"
         multiDexEnabled = true
         // http://developer.android.com/tools/building/multidex.html#testing
         testInstrumentationRunner "com.boundlessgeo.spatialconnect.test.MultiDexAndroidJUnitRunner"

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
@@ -115,7 +115,6 @@ public class SCFormConfig {
         json.put("form_label", getFormLabel());
         json.put("version", getVersion());
         json.put("fields", getFields());
-        json.put("fields", getFields());
 
         return json;
     }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
@@ -3,6 +3,8 @@ package com.boundlessgeo.spatialconnect.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class SCFormConfig {
@@ -35,7 +37,7 @@ public class SCFormConfig {
      * List of the form fields that define this form.
      */
     @JsonProperty("fields")
-    private List<JsonNode> fields;
+    private List<HashMap<String, Object>> fields;
 
     /**
      * Unique id of the team to which this form belongs.
@@ -57,11 +59,11 @@ public class SCFormConfig {
         this.id = id;
     }
 
-    public List<JsonNode> getFields() {
+    public List<HashMap<String, Object>> getFields() {
         return fields;
     }
 
-    public void setFields(List<JsonNode> fields) {
+    public void setFields(List<HashMap<String, Object>> fields) {
         this.fields = fields;
     }
 
@@ -103,6 +105,19 @@ public class SCFormConfig {
 
     public void setMetadata(FormMetadata metadata) {
         this.metadata = metadata;
+    }
+
+    public HashMap<String, Object> toJSON() {
+        HashMap<String, Object> json = new HashMap<>();
+
+        json.put("id", getId());
+        json.put("form_key", getFormKey());  // same as layer name
+        json.put("form_label", getFormLabel());
+        json.put("version", getVersion());
+        json.put("fields", getFields());
+        json.put("fields", getFields());
+
+        return json;
     }
 
     @Override

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormField.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormField.java
@@ -5,6 +5,8 @@ import android.text.TextUtils;
 import com.boundlessgeo.spatialconnect.scutilities.Json.JsonUtilities;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.HashMap;
+
 public class SCFormField {
 
     public static final String FIELD_KEY = "field_key";
@@ -13,7 +15,7 @@ public class SCFormField {
 
     private static final String IS_INTEGER = "is_integer";
 
-    public static String getColumnType(JsonNode field) {
+    public static String getColumnType(HashMap<String, Object> field) {
         String type = JsonUtilities.getString(field, TYPE);
 
         if (TextUtils.isEmpty(type)) {
@@ -24,7 +26,7 @@ public class SCFormField {
             case "string":
                 return "TEXT";
             case "number":
-                return field.get(IS_INTEGER) != null && field.get(IS_INTEGER).asBoolean() ?
+                return JsonUtilities.getBoolean(field, IS_INTEGER) ?
                         "INTEGER" : "REAL";
             case "boolean":
                 return "INTEGER";

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/geometries/SCSpatialFeature.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/geometries/SCSpatialFeature.java
@@ -22,9 +22,14 @@ import com.boundlessgeo.spatialconnect.scutilities.Json.SCObjectMapper;
 import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -49,6 +54,118 @@ public class SCSpatialFeature
         this.metadata.put("layerId", layerId);
         this.metadata.put("storeId", storeId);
     }
+
+//    public SCSpatialFeature(HashMap<String, Object> jsonMap) {
+//        // TODO
+//
+//        SCGeometryFactory factory = new SCGeometryFactory();
+//        SCSpatialFeature feature = new SCSpatialFeature();
+//
+//        String id = null;
+//        String created = null;
+//        String modified = null;
+//        Map<String, Object> properties = null;
+//
+//        try
+//        {
+//            ObjectMapper mapper = SCObjectMapper.getMapper();
+//            JsonNode node = mapper.readTree(json);
+//
+//            JsonNode idNode = node.get("id");
+//            if(idNode != null)
+//            {
+//                id = idNode.asText();
+//            }
+//
+//            JsonNode dateNode = node.get("created");
+//            if (dateNode != null)
+//            {
+//                created = dateNode.asText();
+//            }
+//
+//            dateNode = node.get("modified");
+//            if (dateNode != null)
+//            {
+//                modified = dateNode.asText();
+//            }
+//
+//            JsonNode geometryNode = node.get("geometry");
+//
+//            if (geometryNode != null) {
+//                SCGeometry scGeometry;
+//                String type = geometryNode.get("type").asText();
+//                String geomJson = geometryNode.toString();
+//
+//                switch (type.toLowerCase(Locale.US))
+//                {
+//                    case "point":
+//                        scGeometry = factory.getPointFromGeoJson(geomJson);
+//                        break;
+//                    case "linestring":
+//                        scGeometry = factory.getLineStringFromGeoJson(geomJson);
+//                        break;
+//                    case "polygon":
+//                        scGeometry = factory.getPolygonFromGeoJson(geomJson);
+//                        break;
+//                    case "multipoint":
+//                        scGeometry = factory.getMultiPointFromGeoJson(geomJson);
+//                        break;
+//                    case "multilinestring":
+//                        scGeometry = factory.getMultiLineStringFromGeoJson(geomJson);
+//                        break;
+//                    case "multipolygon":
+//                        scGeometry = factory.getMultiPolygonFromGeoJson(geomJson);
+//                        break;
+//                    default:
+//                        return null;
+//                }
+//                feature = scGeometry;
+//            }
+//
+//            JavaType javaType = mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
+//
+//            JsonNode propertiesNode = node.get("properties");
+//            if (propertiesNode != null)
+//            {
+//                properties = mapper.readValue(propertiesNode.traverse(), javaType);
+//            }
+//
+//            if(id != null)
+//            {
+//                feature.setId(id);
+//            }
+//            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+//            if(created != null)
+//            {
+//                feature.setCreated(formatter.parse(created));
+//            }
+//            if(modified != null)
+//            {
+//                feature.setModified(formatter.parse(modified));
+//            }
+//            if(properties != null)
+//            {
+//                feature.setProperties(properties);
+//            }
+//            JsonNode layerIdNode = node.get("layerId");
+//            if(layerIdNode != null)
+//            {
+//                feature.setLayerId(layerIdNode.asText());
+//            }
+//            JsonNode storeIdNode = node.get("storeId");
+//            if(storeIdNode != null)
+//            {
+//                feature.setStoreId(storeIdNode.asText());
+//            }
+//        }
+//        catch (Exception ex)
+//        {
+//            //Log.e(TAG, "Error in getFeatureFromGeoJson(String)", ex);
+//            ex.printStackTrace();
+//        }
+//
+//        return feature;
+//    }
 
     public String getId()
     {
@@ -145,4 +262,12 @@ public class SCSpatialFeature
 
         return map;
     }
+
+//    public HashMap<String, Object> toJSON() {
+//        HashMap<String, Object> json = new HashMap<>();
+//
+//        // TODO
+//
+//        return json;
+//    }
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/geometries/SCSpatialFeature.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/geometries/SCSpatialFeature.java
@@ -18,6 +18,7 @@ package com.boundlessgeo.spatialconnect.geometries;
 import android.util.Log;
 
 import com.boundlessgeo.spatialconnect.SpatialConnect;
+import com.boundlessgeo.spatialconnect.scutilities.Json.JsonUtilities;
 import com.boundlessgeo.spatialconnect.scutilities.Json.SCObjectMapper;
 import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -35,6 +36,7 @@ import java.util.UUID;
 
 public class SCSpatialFeature
 {
+
     /**
      * For a GeoPackage, the ID will follow the convention storeId.featureTableName.idOfRow
      */
@@ -54,118 +56,6 @@ public class SCSpatialFeature
         this.metadata.put("layerId", layerId);
         this.metadata.put("storeId", storeId);
     }
-
-//    public SCSpatialFeature(HashMap<String, Object> jsonMap) {
-//        // TODO
-//
-//        SCGeometryFactory factory = new SCGeometryFactory();
-//        SCSpatialFeature feature = new SCSpatialFeature();
-//
-//        String id = null;
-//        String created = null;
-//        String modified = null;
-//        Map<String, Object> properties = null;
-//
-//        try
-//        {
-//            ObjectMapper mapper = SCObjectMapper.getMapper();
-//            JsonNode node = mapper.readTree(json);
-//
-//            JsonNode idNode = node.get("id");
-//            if(idNode != null)
-//            {
-//                id = idNode.asText();
-//            }
-//
-//            JsonNode dateNode = node.get("created");
-//            if (dateNode != null)
-//            {
-//                created = dateNode.asText();
-//            }
-//
-//            dateNode = node.get("modified");
-//            if (dateNode != null)
-//            {
-//                modified = dateNode.asText();
-//            }
-//
-//            JsonNode geometryNode = node.get("geometry");
-//
-//            if (geometryNode != null) {
-//                SCGeometry scGeometry;
-//                String type = geometryNode.get("type").asText();
-//                String geomJson = geometryNode.toString();
-//
-//                switch (type.toLowerCase(Locale.US))
-//                {
-//                    case "point":
-//                        scGeometry = factory.getPointFromGeoJson(geomJson);
-//                        break;
-//                    case "linestring":
-//                        scGeometry = factory.getLineStringFromGeoJson(geomJson);
-//                        break;
-//                    case "polygon":
-//                        scGeometry = factory.getPolygonFromGeoJson(geomJson);
-//                        break;
-//                    case "multipoint":
-//                        scGeometry = factory.getMultiPointFromGeoJson(geomJson);
-//                        break;
-//                    case "multilinestring":
-//                        scGeometry = factory.getMultiLineStringFromGeoJson(geomJson);
-//                        break;
-//                    case "multipolygon":
-//                        scGeometry = factory.getMultiPolygonFromGeoJson(geomJson);
-//                        break;
-//                    default:
-//                        return null;
-//                }
-//                feature = scGeometry;
-//            }
-//
-//            JavaType javaType = mapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class);
-//
-//            JsonNode propertiesNode = node.get("properties");
-//            if (propertiesNode != null)
-//            {
-//                properties = mapper.readValue(propertiesNode.traverse(), javaType);
-//            }
-//
-//            if(id != null)
-//            {
-//                feature.setId(id);
-//            }
-//            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-//            if(created != null)
-//            {
-//                feature.setCreated(formatter.parse(created));
-//            }
-//            if(modified != null)
-//            {
-//                feature.setModified(formatter.parse(modified));
-//            }
-//            if(properties != null)
-//            {
-//                feature.setProperties(properties);
-//            }
-//            JsonNode layerIdNode = node.get("layerId");
-//            if(layerIdNode != null)
-//            {
-//                feature.setLayerId(layerIdNode.asText());
-//            }
-//            JsonNode storeIdNode = node.get("storeId");
-//            if(storeIdNode != null)
-//            {
-//                feature.setStoreId(storeIdNode.asText());
-//            }
-//        }
-//        catch (Exception ex)
-//        {
-//            //Log.e(TAG, "Error in getFeatureFromGeoJson(String)", ex);
-//            ex.printStackTrace();
-//        }
-//
-//        return feature;
-//    }
 
     public String getId()
     {
@@ -251,10 +141,10 @@ public class SCSpatialFeature
         return null;
     }
 
-    public  Map<String, Object> toMap() {
-        Map<String, Object> map = null;
+    public HashMap<String, Object> toMap() {
+        HashMap<String, Object> map = null;
         try {
-            map = SCObjectMapper.getMapper().convertValue(this,  Map.class);
+            map = SCObjectMapper.getMapper().convertValue(this,  HashMap.class);
             map.put("type", "Feature");
         } catch (Exception e) {
             Log.e(LOG_TAG, "error converting to map: " + e.getMessage());
@@ -263,11 +153,9 @@ public class SCSpatialFeature
         return map;
     }
 
-//    public HashMap<String, Object> toJSON() {
-//        HashMap<String, Object> json = new HashMap<>();
-//
-//        // TODO
-//
-//        return json;
-//    }
+    public HashMap<String, Object> toJSON() {
+        return toMap();
+
+        // TODO eventually should change this to write to a HashMap on it's own, without using objectmapper
+    }
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptBridgeAPI.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptBridgeAPI.java
@@ -1,0 +1,519 @@
+package com.boundlessgeo.spatialconnect.jsbridge;
+
+import android.content.Context;
+import android.location.Location;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.boundlessgeo.schema.Actions;
+import com.boundlessgeo.spatialconnect.SpatialConnect;
+import com.boundlessgeo.spatialconnect.config.SCFormConfig;
+import com.boundlessgeo.spatialconnect.geometries.SCBoundingBox;
+import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
+import com.boundlessgeo.spatialconnect.mqtt.SCNotification;
+import com.boundlessgeo.spatialconnect.query.SCGeometryPredicateComparison;
+import com.boundlessgeo.spatialconnect.query.SCPredicate;
+import com.boundlessgeo.spatialconnect.query.SCQueryFilter;
+import com.boundlessgeo.spatialconnect.scutilities.Json.JsonUtilities;
+import com.boundlessgeo.spatialconnect.services.SCBackendService;
+import com.boundlessgeo.spatialconnect.services.SCSensorService;
+import com.boundlessgeo.spatialconnect.services.SCServiceStatusEvent;
+import com.boundlessgeo.spatialconnect.services.authService.SCAuthService;
+import com.boundlessgeo.spatialconnect.stores.ISCSpatialStore;
+import com.boundlessgeo.spatialconnect.stores.SCDataStore;
+import com.boundlessgeo.spatialconnect.stores.SCKeyTuple;
+import com.boundlessgeo.spatialconnect.stores.SCRasterStore;
+import com.boundlessgeo.spatialconnect.stores.SCStoreStatusEvent;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import rx.Subscriber;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
+
+public class SCJavascriptBridgeAPI {
+
+    private static final String TAG = SCJavascriptBridgeAPI.class.getSimpleName();
+
+    private SpatialConnect mSpatialConnect;
+
+    SCJavascriptBridgeAPI(Context context) {
+        mSpatialConnect = SpatialConnect.getInstance();
+        mSpatialConnect.initialize(context);
+    }
+
+        /**
+     * Handles a message sent from Javascript.  Expects the message envelope to look like:
+     * <code>{"type":<String>,"payload":<JSON Object>}</code>
+     *
+     * @param jsonMessage message received from Javascript
+     */
+    public void parseJSAction(HashMap<String, Object> jsonMessage, Subscriber<Object> subscriber) {
+        if (jsonMessage == null) {
+            subscriber.onCompleted();
+            return;
+        }
+
+            // parse bridge message to determine command
+        String type = JsonUtilities.getString(jsonMessage, "type");
+        if (TextUtils.isEmpty(type)) {
+            return;
+        }
+        Actions command = Actions.fromAction(type);
+
+        Log.d(TAG, "sdk handling: " + command + " :: " + jsonMessage);
+            if (command == Actions.START_ALL_SERVICES) {
+                handleStartAllServices();
+            }
+            else if (command == Actions.DATASERVICE_ACTIVESTORESLIST) {
+                handleActiveStoresList(subscriber);
+            }
+            else if (command == Actions.DATASERVICE_ACTIVESTOREBYID) {
+                handleActiveStoreById(JsonUtilities.getHashMap(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.DATASERVICE_STORELIST) {
+                handleStoreList(subscriber);
+            }
+            else if (command == Actions.DATASERVICE_QUERY
+                    || command == Actions.DATASERVICE_SPATIALQUERY) {
+                handleQueryStoresByIds(JsonUtilities.getHashMap(jsonMessage, "payload"), subscriber);
+        }
+        else if ( command == Actions.DATASERVICE_QUERYALL
+                    || command == Actions.DATASERVICE_SPATIALQUERYALL) {
+                handleQueryAllStores(JsonUtilities.getHashMap(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.DATASERVICE_CREATEFEATURE) {
+                handleCreateFeature(JsonUtilities.getHashMap(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.DATASERVICE_UPDATEFEATURE) {
+                handleUpdateFeature(JsonUtilities.getHashMap(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.DATASERVICE_DELETEFEATURE) {
+                handleDeleteFeature(JsonUtilities.getString(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.DATASERVICE_FORMLIST) {
+                handleFormsList(subscriber);
+            }
+            else if (command == Actions.SENSORSERVICE_GPS) {
+                handleSensorServiceGps(JsonUtilities.getInt(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.AUTHSERVICE_AUTHENTICATE) {
+                handleAuthenticate(JsonUtilities.getHashMap(jsonMessage, "payload"), subscriber);
+            }
+            else if (command == Actions.AUTHSERVICE_LOGOUT) {
+                handleLogout(subscriber);
+            }
+            else if (command == Actions.AUTHSERVICE_ACCESS_TOKEN) {
+                handleAccessToken(subscriber);
+            }
+            else if (command == Actions.AUTHSERVICE_LOGIN_STATUS) {
+                handleLoginStatus(subscriber);
+            }
+            else if (command == Actions.NOTIFICATIONS) {
+                handleNotificationSubscribe(subscriber);
+            }
+            else if (command == Actions.BACKENDSERVICE_HTTP_URI) {
+                handleBackendServiceHTTPUri(subscriber);
+            }
+            else if (command == Actions.BACKENDSERVICE_MQTT_CONNECTED) {
+                handleMqttConnectionStatus(subscriber);
+            }
+        }
+
+    /**
+     * Handles the {@link Actions#START_ALL_SERVICES} command.
+     */
+    private void handleStartAllServices() {
+        mSpatialConnect.startAllServices();
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_ACTIVESTORESLIST} command.
+     */
+    private void handleActiveStoresList(final Subscriber<Object> subscriber) {
+        mSpatialConnect.getDataService()
+                .hasStores
+                .subscribe(new Action1<Boolean>() {
+                    @Override
+                    public void call(Boolean hasStores) {
+                        if (hasStores) {
+                            HashMap<String, Object> payload = new HashMap<>();
+
+                            List<SCDataStore> stores = mSpatialConnect.getDataService().getActiveStores();
+                            ArrayList<HashMap<String, Object>> storesArray = new ArrayList<>();
+                            for (SCDataStore store : stores) {
+                                storesArray.add(getStoreMap(store));
+                            }
+
+                            payload.put("stores", storesArray);
+
+                            subscriber.onNext(payload);
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Handles all the {@link Actions#DATASERVICE_ACTIVESTOREBYID} commands.
+     */
+    private void handleActiveStoreById(HashMap<String, Object> payload, Subscriber<Object> subscriber) {
+        String storeId = JsonUtilities.getString(payload, "storeId");
+        SCDataStore store = mSpatialConnect.getDataService().getStoreByIdentifier(storeId);
+        subscriber.onNext(getStoreMap(store));
+        subscriber.onCompleted();
+    }
+
+    /**
+     * Handles all the {@link Actions#DATASERVICE_STORELIST} commands.
+     */
+    private void handleStoreList(final Subscriber<Object> subscriber) {
+        subscriber.onNext(getAllStoresPayload());
+
+        mSpatialConnect.getDataService().getStoreEvents().subscribe(new Action1<SCStoreStatusEvent>() {
+            @Override
+            public void call(SCStoreStatusEvent scStoreStatusEvent) {
+                subscriber.onNext(getAllStoresPayload());
+            }
+        });
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_QUERYALL} and
+     * {@link Actions#DATASERVICE_SPATIALQUERYALL} commands.
+     */
+    private void handleQueryAllStores(HashMap<String, Object> payload, final Subscriber<Object> subscriber) {
+        SCQueryFilter filter = getFilter(JsonUtilities.getHashMap(payload, "filter"));
+
+        mSpatialConnect.getDataService().queryAllStores(filter)
+                .subscribeOn(Schedulers.io())
+                .subscribe(new Action1<SCSpatialFeature>() {
+                    @Override
+                    public void call(SCSpatialFeature feature) {
+                        try {
+                            // base64 encode id and set it before sending across wire
+                            String encodedId = feature.getKey().encodedCompositeKey();
+                            feature.setId(encodedId);
+                            subscriber.onNext(feature.toJSON()); // TODO or new JSONObject(feature.toJson())
+                        }
+                        catch (UnsupportedEncodingException e) {
+                            subscriber.onError(e);
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_QUERY} and
+     * {@link Actions#DATASERVICE_SPATIALQUERY} commands.
+     */
+    private void handleQueryStoresByIds(HashMap<String, Object> payload, final Subscriber<Object> subscriber) {
+        SCQueryFilter filter = getFilter(JsonUtilities.getHashMap(payload, "filter"));
+
+        ArrayList<String> storeIds = JsonUtilities.getArrayList(payload, "storeId", String.class);
+
+        mSpatialConnect.getDataService().queryStoresByIds(storeIds, filter)
+                .subscribeOn(Schedulers.io())
+                .subscribe(new Action1<SCSpatialFeature>() {
+                    @Override
+                    public void call(SCSpatialFeature feature) {
+                        try {
+                            // base64 encode id and set it before sending across wire
+                            String encodedId = feature.getKey().encodedCompositeKey();
+                            feature.setId(encodedId);
+                            subscriber.onNext(feature.toJSON()); // TODO or new JSONObject(feature.toJson())
+                        }
+                        catch (UnsupportedEncodingException e) {
+                            subscriber.onError(e);
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_CREATEFEATURE} command.
+     */
+    private void handleCreateFeature(HashMap<String, Object> payload, final Subscriber<Object> subscriber) {
+            SCSpatialFeature newFeature = new SCSpatialFeature(JsonUtilities.getHashMap(payload, "feature"));
+            // if no store was specified, use the default store
+            if (newFeature.getKey().getStoreId() == null || newFeature.getKey().getStoreId().isEmpty()) {
+                newFeature.setStoreId(newFeature.getKey().getStoreId());
+            }
+            SCDataStore store = mSpatialConnect.getDataService().getStoreByIdentifier(newFeature.getKey().getStoreId());
+            ((ISCSpatialStore) store).create(newFeature)
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(
+                    new Action1<SCSpatialFeature>() {
+                @Override
+                public void call(SCSpatialFeature feature) {
+                    try {
+                        // base64 encode id and set it before sending across wire
+                        String encodedId = feature.getKey().encodedCompositeKey();
+                        feature.setId(encodedId);
+                        subscriber.onNext(feature.toJSON());
+                    }
+                    catch (UnsupportedEncodingException e) {
+                        subscriber.onError(e);
+                    }
+                    }
+                });
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_UPDATEFEATURE} command.
+     */
+    private void handleUpdateFeature(HashMap<String, Object> payload, Subscriber<Object> subscriber) {
+        SCSpatialFeature feature = new SCSpatialFeature(JsonUtilities.getHashMap(payload, "feature"));
+        try {
+        SCKeyTuple decodedTuple = new SCKeyTuple(feature.getId());
+        // update feature with decoded values
+        feature.setStoreId(decodedTuple.getStoreId());
+        feature.setLayerId(decodedTuple.getLayerId());
+        feature.setId(decodedTuple.getFeatureId());
+        } catch (UnsupportedEncodingException e) {
+            subscriber.onError(e);
+        }
+
+            SCDataStore store = mSpatialConnect.getDataService().getStoreByIdentifier(feature.getKey().getStoreId());
+            ((ISCSpatialStore) store).update(feature).subscribeOn(Schedulers.io()).subscribe(subscriber);
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_DELETEFEATURE} command.
+     */
+    private void handleDeleteFeature(String payload, Subscriber subscriber) {
+        try {
+            SCKeyTuple featureKey = new SCKeyTuple(payload);
+            SCDataStore store = mSpatialConnect.getDataService().getStoreByIdentifier(featureKey.getStoreId());
+            ((ISCSpatialStore) store).delete(featureKey).subscribeOn(Schedulers.io()).subscribe(subscriber);
+        }
+        catch (UnsupportedEncodingException e) {
+            subscriber.onError(e);
+        }
+    }
+
+    /**
+     * Handles the {@link Actions#DATASERVICE_FORMLIST} command.
+     */
+    private void handleFormsList(final Subscriber<Object> subscriber) {
+        mSpatialConnect.getDataService()
+                .getFormStore()
+                .hasForms
+                .subscribe(new Action1<Boolean>() {
+                    @Override
+                    public void call(Boolean hasForms) {
+                        if (hasForms)  {
+                            HashMap<String, Object> payload = new HashMap<>();
+
+                            List<SCFormConfig> formConfigs =
+                                    mSpatialConnect.getDataService().getFormStore().getFormConfigs();
+                            ArrayList<HashMap<String, Object>> formsArray = new ArrayList<>();
+                            for (SCFormConfig config : formConfigs) {
+                                formsArray.add(config.toJSON());
+                            }
+
+                            payload.put("forms", formsArray);
+
+                            subscriber.onNext(payload);
+                        }
+                    }
+                });
+
+    }
+
+    /**
+     * Handles all the {@link Actions#SENSORSERVICE_GPS} commands.
+     */
+    private void handleSensorServiceGps(int payload, final Subscriber<Object> subscriber) {
+        SCSensorService sensorService = mSpatialConnect.getSensorService();
+        if (payload == 1) {
+            sensorService.enableGPS();
+            sensorService.getLastKnownLocation()
+                    .subscribeOn(Schedulers.newThread())
+                    .subscribe(new Action1<Location>() {
+                        @Override
+                        public void call(Location location) {
+                            HashMap<String, Object> payload = new HashMap<>();
+
+                            payload.put("latitude", location.getLatitude());
+                            payload.put("longitude", location.getLongitude());
+                            payload.put("altitude", location.getAltitude());
+
+                            subscriber.onNext(payload);
+                        }
+                    });
+        }
+        if (payload == 0) {
+            sensorService.disableGPS();
+        }
+    }
+
+    private void handleAuthenticate(HashMap<String, Object> payload, final Subscriber<Object> subscriber) {
+        String email = JsonUtilities.getString(payload, "email");
+        String password = JsonUtilities.getString(payload, "password");
+        SCAuthService authService = SpatialConnect.getInstance().getAuthService();
+        authService.authenticate(email, password);
+        subscriber.onCompleted();
+    }
+
+    private void handleLogout(Subscriber subscriber) {
+        SpatialConnect.getInstance().getAuthService().logout();
+        subscriber.onCompleted();
+    }
+
+    private void handleAccessToken(Subscriber<Object> subscriber) {
+        SCAuthService authService = SpatialConnect.getInstance().getAuthService();
+        String accessToken = authService.getAccessToken();
+        if (accessToken != null) {
+            subscriber.onNext(accessToken);
+        }
+        subscriber.onCompleted();
+    }
+
+    /**
+     * Handles the {@link Actions#AUTHSERVICE_LOGIN_STATUS} command.
+     */
+    private void handleLoginStatus(final Subscriber<Object> subscriber) {
+        mSpatialConnect.serviceRunning(SCAuthService.serviceId())
+                .subscribe(new Action1<SCServiceStatusEvent>() {
+                    @Override
+                    public void call(SCServiceStatusEvent scServiceStatusEvent) {
+                        SCAuthService authService = SpatialConnect.getInstance().getAuthService();
+                        authService.getLoginStatus().subscribe(new Action1<Integer>() {
+                            @Override
+                            public void call(Integer status) {
+                                subscriber.onNext(status);
+                            }
+                        });
+                    }
+                });
+    }
+
+    private void handleNotificationSubscribe(final Subscriber<Object> subscriber) {
+        SCSensorService sensorService = SpatialConnect.getInstance().getSensorService();
+        sensorService.isConnected().subscribe(new Action1<Boolean>() {
+            @Override
+            public void call(Boolean connected) {
+                if (connected) {
+                    final SpatialConnect sc = SpatialConnect.getInstance();
+                    sc.serviceRunning(SCBackendService.serviceId())
+                            .subscribe(new Action1<SCServiceStatusEvent>() {
+                                @Override
+                                public void call(SCServiceStatusEvent scServiceStatusEvent) {
+                                    sc.getBackendService()
+                                            .getNotifications()
+                                            .subscribe(new Action1<SCNotification>() {
+                                                @Override
+                                                public void call(SCNotification scNotification) {
+                                                    subscriber.onNext(scNotification.toJSON());
+                                                }
+                                            });
+                                }
+                            });
+                }
+            }
+        });
+
+    }
+
+    /**
+     * Handles the {@link Actions#BACKENDSERVICE_HTTP_URI} command.
+     */
+    private void handleBackendServiceHTTPUri(final Subscriber<Object> subscriber) {
+        mSpatialConnect.serviceRunning(SCBackendService.serviceId())
+                .subscribe(new Action1<SCServiceStatusEvent>() {
+                    @Override
+                    public void call(SCServiceStatusEvent scServiceStatusEvent) {
+                        HashMap<String, Object> payload = new HashMap<>();
+                        payload.put("backendUri", mSpatialConnect.getBackendService().backendUri + "/api/");
+
+                        subscriber.onNext(payload);
+                    }
+                });
+
+    }
+
+    /**
+     * Handles the {@link Actions#BACKENDSERVICE_MQTT_CONNECTED} command.
+     */
+    private void handleMqttConnectionStatus(final Subscriber<Object> subscriber) {
+        SpatialConnect sc = SpatialConnect.getInstance();
+        SCBackendService backendService = sc.getBackendService();
+        if (backendService != null) {
+            backendService
+                    .connectedToBroker
+                    .subscribeOn(Schedulers.io())
+                    .subscribe(new Action1<Boolean>() {
+                        @Override
+                        public void call(Boolean connected) {
+                            HashMap<String, Object> payload = new HashMap<>();
+                            payload.put("connected", connected);
+
+                            subscriber.onNext(payload);
+                        }
+                    });
+        } else {
+            HashMap<String, Object> payload = new HashMap<>();
+            payload.put("connected", false);
+
+            subscriber.onNext(payload);
+        }
+    }
+
+    private HashMap<String, Object> getStoreMap(SCDataStore store) {
+        HashMap<String, Object> json = store.toJSON();
+
+        if (store instanceof ISCSpatialStore) {
+            json.put("vectorLayers", ((ISCSpatialStore) store).vectorLayers());
+        }
+        if (store instanceof SCRasterStore) {
+            json.put("rasterLayers", ((SCRasterStore) store).rasterLayers());
+        }
+
+        return json;
+    }
+
+    private HashMap<String, Object> getAllStoresPayload() {
+        HashMap<String, Object> payload = new HashMap<>();
+        ArrayList<HashMap<String, Object>> storesArray = new ArrayList<>();
+
+        List<SCDataStore> stores = mSpatialConnect.getDataService().getStoreList();
+        for (SCDataStore store : stores) {
+            storesArray.add(getStoreMap(store));
+        }
+        payload.put("stores", storesArray);
+
+        return payload;
+    }
+
+    // builds a query filter based on the filter in payload
+    private SCQueryFilter getFilter(HashMap<String, Object> filterJSON) {
+        SCBoundingBox bbox;
+
+        ArrayList<Double> coords = JsonUtilities.getArrayList(filterJSON, "$geocontains", Double.class);
+        // if a bounding box was provided, use it
+        if (coords != null && coords.size() >= 3 ) {
+            bbox = new SCBoundingBox(coords.get(0), coords.get(1), coords.get(2), coords.get(3));
+        }
+        // otherwise use the world
+        else {
+            bbox = new SCBoundingBox(-180, -90, 180, 90);
+        }
+
+        SCQueryFilter filter = new SCQueryFilter(
+                new SCPredicate(bbox, SCGeometryPredicateComparison.SCPREDICATE_OPERATOR_WITHIN));
+
+        // add layers to filter
+        if (filterJSON.containsKey("layers")) {
+            filter.addLayerIds(JsonUtilities.getArrayList(filterJSON, "layers", String.class));
+        }
+
+        // add limit
+        if (filterJSON.containsKey("limit")) {
+            filter.setLimit(JsonUtilities.getInt(filterJSON, "limit"));
+        }
+        return filter;
+    }
+}

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptCommands.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/SCJavascriptCommands.java
@@ -1,0 +1,18 @@
+package com.boundlessgeo.spatialconnect.jsbridge;
+
+public class SCJavascriptCommands {
+
+    public enum SCBridgeStatus {
+        NEXT(0), COMPLETED(1), ERROR(2);
+
+        private final int mStatus;
+
+        SCBridgeStatus(int status) {
+            mStatus = status;
+        }
+
+        public int statusValue() {
+            return mStatus;
+        }
+    }
+}

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/mqtt/SCNotification.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/mqtt/SCNotification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2017 Boundless, http://boundlessgeo.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,8 @@ import com.boundlessgeo.schema.MessagePbf;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.HashMap;
 
 public class SCNotification {
 
@@ -43,19 +45,16 @@ public class SCNotification {
         }
     }
 
-    public JSONObject toJson() {
-        JSONObject obj = new JSONObject();
-        try {
-            obj.put("to" , to);
-            obj.put("title", title);
-            obj.put("body", body);
-            obj.put("payload", payload);
-            obj.put("priority", priority);
-        }
-        catch (JSONException e) {
-            Log.e("SCNotification", "Could not transform notification into json", e);
-        }
-        return obj;
+    public HashMap<String, Object> toJSON() {
+        HashMap<String, Object> json = new HashMap<>();
+
+        json.put("to" , to);
+        json.put("title", title);
+        json.put("body", body);
+        json.put("payload", payload);
+        json.put("priority", priority);
+
+        return json;
     }
 
 }

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/query/SCQueryFilter.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/query/SCQueryFilter.java
@@ -20,20 +20,15 @@ import java.util.List;
 
 public class SCQueryFilter
 {
-    //private List<SCPredicate> predicates;
     private SCPredicate predicate;
-    private List<String> layerIds;
+    private List<String> mLayerIds = new ArrayList<>();
     private String featureId;
 
     private int limit = 100;
 
-    public SCQueryFilter() {
-        layerIds = new ArrayList<>();
-    }
-
     public SCQueryFilter(SCPredicate scPredicate)
     {
-        this.layerIds = new ArrayList<>();
+        mLayerIds = new ArrayList<>();
         this.predicate = scPredicate;
     }
 
@@ -43,11 +38,15 @@ public class SCQueryFilter
     }
 
     public void addLayerId(String id) {
-        layerIds.add(id);
+        mLayerIds.add(id);
     }
 
     public List<String> getLayerIds() {
-        return this.layerIds;
+        return mLayerIds;
+    }
+
+    public void addLayerIds(List<String> layerIds) {
+        mLayerIds.addAll(layerIds);
     }
 
     public int getLimit() {

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/Json/JsonUtilities.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/Json/JsonUtilities.java
@@ -26,12 +26,45 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 public class JsonUtilities
 {
+
+    public static int getInt(HashMap<String, Object> json, String name) {
+        return getInt(json, name, 0);
+    }
+
+    public static Integer getInt(Map json, String name, Integer fallback) {
+        // this cannot be a conditional expression (single-line if)
+        // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.25
+        if ( hasKey(json, name) ) {
+            return toInt(json.get(name));
+        }
+        else {
+            return fallback;
+        }
+    }
+
+    public static <T> ArrayList<T> getArrayList(Map json, String name, Class<T> cls) {
+        return hasKey(json, name) ? toArrayList(json.get(name), cls) : null;
+    }
+
+    public static HashMap<String, Object> getHashMap(HashMap<String, Object> json, String name) {
+        return hasKey(json, name) ? toHashMap(json.get(name)) : null;
+    }
+
+    public static String getString(HashMap<String, Object> json, String name) {
+        return getString(json, name, null);
+    }
+
+    public static String getString(Map json, String name, String fallback) {
+        return hasKey(json, name) ? (String) json.get(name) : fallback;
+    }
 
     public static String getString(JsonNode json, String name) {
         return getString(json, name, null);
@@ -39,6 +72,22 @@ public class JsonUtilities
 
     public static String getString(JsonNode json, String name, String fallback) {
         return json.has(name) ? json.get(name).asText() : fallback;
+    }
+
+    public static boolean hasKey(Map json, String key) {
+        return json != null && json.get(key) != null;
+    }
+
+    private static HashMap<String, Object> toHashMap(Object object) {
+        return object instanceof HashMap ? (HashMap<String, Object>) object : null;
+    }
+
+    private static <T> ArrayList<T> toArrayList(Object array, Class<T> cls) {
+        return array instanceof ArrayList ? (ArrayList<T>) array : null;
+    }
+
+    private static int toInt(Object number) {
+        return ((Number) number).intValue();
     }
 
     private final String TAG = "JsonUtilities";

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/Json/JsonUtilities.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/scutilities/Json/JsonUtilities.java
@@ -35,11 +35,15 @@ import java.util.Map;
 public class JsonUtilities
 {
 
+    public static boolean getBoolean(HashMap<String, Object> json, String name) {
+        return hasKey(json, name) && (boolean) json.get(name);
+    }
+
     public static int getInt(HashMap<String, Object> json, String name) {
         return getInt(json, name, 0);
     }
 
-    public static Integer getInt(Map json, String name, Integer fallback) {
+    public static Integer getInt(HashMap<String, Object> json, String name, Integer fallback) {
         // this cannot be a conditional expression (single-line if)
         // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.25
         if ( hasKey(json, name) ) {
@@ -50,7 +54,7 @@ public class JsonUtilities
         }
     }
 
-    public static <T> ArrayList<T> getArrayList(Map json, String name, Class<T> cls) {
+    public static <T> ArrayList<T> getArrayList(HashMap<String, Object> json, String name, Class<T> cls) {
         return hasKey(json, name) ? toArrayList(json.get(name), cls) : null;
     }
 
@@ -62,7 +66,7 @@ public class JsonUtilities
         return getString(json, name, null);
     }
 
-    public static String getString(Map json, String name, String fallback) {
+    public static String getString(HashMap<String, Object> json, String name, String fallback) {
         return hasKey(json, name) ? (String) json.get(name) : fallback;
     }
 
@@ -74,7 +78,7 @@ public class JsonUtilities
         return json.has(name) ? json.get(name).asText() : fallback;
     }
 
-    public static boolean hasKey(Map json, String key) {
+    public static boolean hasKey(HashMap<String, Object> json, String key) {
         return json != null && json.get(key) != null;
     }
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java
@@ -132,7 +132,7 @@ public class FormStore extends GeoPackageStore implements ISCSpatialStore, SCDat
         boolean fieldsValid = true;
 
         Map<String, String> typeDefs = new HashMap<>();
-        for (JsonNode field : config.getFields()) {
+        for (HashMap<String, Object> field : config.getFields()) {
             String fieldKey = JsonUtilities.getString(field, SCFormField.FIELD_KEY);
             if (!TextUtils.isEmpty(fieldKey)) {
                 typeDefs.put(fieldKey, SCFormField.getColumnType(field));

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCDataStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/SCDataStore.java
@@ -157,6 +157,25 @@ public abstract class SCDataStore {
         return storeMap;
     }
 
+    public HashMap<String, Object> toJSON() {
+        HashMap<String, Object> json = new HashMap<>();
+
+        json.put("storeId", getStoreId());
+        json.put("name", getName());
+        json.put("type", getType());
+        json.put("version", getVersion());
+        json.put("key", getKey());
+        json.put("status", getStatus().ordinal());
+        json.put("downloadProgress", getDownloadProgress());
+
+        SCStyle style = getStyle();
+        if (style != null) {
+            json.put("style", style.toJSON());
+        }
+
+        return json;
+    }
+
     @Override
     public String toString() {
         return storeId + "." + name;

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/style/SCStyle.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/style/SCStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2017 Boundless, http://boundlessgeo.com
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +20,11 @@ import android.util.Log;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import java.util.HashMap;
+
 public class SCStyle {
 
-    private String LOG_TAG = SCStyle.class.getSimpleName();
+    private static final String LOG_TAG = SCStyle.class.getSimpleName();
     private String fillColor = null;
     private float fillOpacity = 0;
     private String strokeColor = null;
@@ -130,5 +132,17 @@ public class SCStyle {
         if (style.getIconColor() != null) {
             this.iconColor = style.getIconColor();
         }
+    }
+
+    public HashMap<String, Object> toJSON() {
+        HashMap<String, Object> json = new HashMap<>();
+
+        json.put("fillColor", getFillColor());
+        json.put("fillOpacity", getFillOpacity());
+        json.put("strokeColor", getStrokeColor());
+        json.put("strokeOpacity", getStrokeOpacity());
+        json.put("iconColor", getIconColor());
+
+        return json;
     }
 }


### PR DESCRIPTION
## Status
**READY**

## JIRA Ticket
UMC-24

## Description
I'm not ready to merge this in yet, I just wanted to get a diff out there for people to look at. Most of the translation is in `SCJavascriptBridgeAPI.java`. I tried to make it match [the iOS counterpart](https://github.com/boundlessgeo/spatialconnect-ios-sdk/blob/develop/SpatialConnect/SCJavascriptBridgeAPI.m) as much as possible.

In the future, we should look at doing some general standardization and cleanup, for both maintainability and efficiency reasons. A code formatter would go a long way towards making the sdk easier to update. Using one mode of JSON de/serializing would speed up and improve code quality.

## Todos
- [ ] Tests

@boundlessgeo/spatial-connect
