### PR TITLE
select sqlite_master produces no such table stat

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/GeoPackage.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/GeoPackage.java
@@ -89,6 +89,8 @@ public class GeoPackage {
             db = new SCSqliteHelper(context, name).db();
             if (initializeSpatialMetadata() && validateGeoPackageSchema()) {
 
+                db.execute("ANALYZE");
+
                 for (SCGpkgFeatureSource source: getFeatureSources().values()) {
                     initializeFeatureSource(source);
                 }


### PR DESCRIPTION
merge behind #200 

## Status
**READY**

## Description
db statements where we select from sqlite_master make use of the sqlite_stat1 table https://sqlite.org/fileformat2.html#stat1tab . this table isnt created until an `ANALYZE` is run https://sqlite.org/lang_analyze.html

@boundlessgeo/spatial-connect
