### PR TITLE
ensure that table and column names do not contain Sqlite keywords

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/config/SCFormConfig.java
@@ -1,5 +1,6 @@
 package com.boundlessgeo.spatialconnect.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -15,6 +16,7 @@ import java.util.List;
  * {@link com.boundlessgeo.spatialconnect.stores.FormStore} to create a GeoPackage vector feature
  * table.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SCFormConfig {
 
     /**

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/GeoPackage.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/GeoPackage.java
@@ -819,9 +819,14 @@ public class GeoPackage {
     }
 
     public void addFeatureSource(String layer, Map<String,String>  fields) {
-        if (addContentsTable(layer, fields)) {
-            addAuditTable(layer, fields);
-            initializeFeatureSource(getFeatureSourceByName(layer));
+        // ensure layer name doesn't contain any invalid characters
+        String tableName = layer.replace(":", "_").replace(".", "_");
+        if (SCSqliteHelper.SQLITE_KEYWORDS.contains(tableName.toUpperCase())) {
+            tableName = tableName + "_";
+        }
+        if (addContentsTable(tableName, fields)) {
+            addAuditTable(tableName, fields);
+            initializeFeatureSource(getFeatureSourceByName(tableName));
         }
     }
 

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/SCGpkgFeatureSource.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/SCGpkgFeatureSource.java
@@ -13,6 +13,7 @@ import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKBReader;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -59,7 +60,6 @@ public class SCGpkgFeatureSource {
      */
     private String geomColumnName;
 
-
     /**
      * A map of the columns and their database types.
      */
@@ -85,7 +85,13 @@ public class SCGpkgFeatureSource {
     }
 
     public void addColumn(String columnName, String columnType) {
-        this.columns.put(columnName, columnType);
+        if (SCSqliteHelper.SQLITE_KEYWORDS.contains(columnName.toUpperCase())) {
+          // append and underscore to the end of the name
+          this.columns.put(columnName + "_", columnType);
+        }
+        else {
+          this.columns.put(columnName, columnType);
+        }
     }
 
     public void setGeomColumnName(String geomColumnName) {

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/SCSqliteHelper.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/SCSqliteHelper.java
@@ -22,6 +22,8 @@ import android.util.Log;
 import com.squareup.sqlbrite.BriteDatabase;
 import com.squareup.sqlbrite.SqlBrite;
 
+import java.util.Arrays;
+import java.util.List;
 import org.sqlite.database.DatabaseErrorHandler;
 import org.sqlite.database.sqlite.SQLiteDatabase;
 import org.sqlite.database.sqlite.SQLiteOpenHelper;
@@ -36,6 +38,22 @@ import rx.schedulers.Schedulers;
  */
 public class SCSqliteHelper extends SQLiteOpenHelper {
 
+    /**
+     * A list of keywords used by Sqlite that we cannot use as table or column names.
+     * https://www.sqlite.org/lang_keywords.html
+     */
+    public static final List<String> SQLITE_KEYWORDS = Arrays.asList(("ABORT,ACTION,ADD,AFTER,"
+        + "ALL,ALTER,ANALYZE,AND,AS,ASC,ATTACH,AUTOINCREMENT,BEFORE,BEGIN,BETWEEN,BY,CASCADE,"
+        + "CASE,CAST,CHECK,COLLATE,COLUMN,COMMIT,CONFLICT,CONSTRAINT,CREATE,CROSS,CURRENT_DATE"
+        + ",CURRENT_TIME,CURRENT_TIMESTAMP,DATABASE,DEFAULT,DEFERRABLE,DEFERRED,DELETE,DESC"
+        + ",DETACH,DISTINCT,DROP,EACH,ELSE,END,ESCAPE,EXCEPT,EXCLUSIVE,EXISTS,EXPLAIN,FAIL,FOR"
+        + ",FOREIGN,FROM,FULL,GLOB,GROUP,HAVING,IF,IGNORE,IMMEDIATE,IN,INDEX,INDEXED,INITIALLY"
+        + ",INNER,INSERT,INSTEAD,INTERSECT,INTO,IS,ISNULL,JOIN,KEY,LEFT,LIKE,LIMIT,MATCH,NATURAL"
+        + ",NO,NOT,NOTNULL,NULL,OF,OFFSET,ON,OR,ORDER,OUTER,PLAN,PRAGMA,PRIMARY,QUERY,RAISE"
+        + ",RECURSIVE,REFERENCES,REGEXP,REINDEX,RELEASE,RENAME,REPLACE,RESTRICT,RIGHT,ROLLBACK,"
+        + "ROW,SAVEPOINT,SELECT,SET,TABLE,TEMP,TEMPORARY,THEN,TO,TRANSACTION,TRIGGER,UNION,"
+        + "UNIQUE,UPDATE,USING,VACUUM,VALUES,VIEW,VIRTUAL,WHEN,WHERE,WITH,WITHOUT")
+        .split(","));
     private static final int DATABASE_VERSION = 1;
     private SqlBrite sqlBrite = SqlBrite.create(new SqlBrite.Logger() {
         @Override

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/stores/FormStore.java
@@ -23,6 +23,7 @@ import android.util.Log;
 import com.boundlessgeo.spatialconnect.config.SCFormConfig;
 import com.boundlessgeo.spatialconnect.config.SCFormField;
 import com.boundlessgeo.spatialconnect.config.SCStoreConfig;
+import com.boundlessgeo.spatialconnect.db.SCSqliteHelper;
 import com.boundlessgeo.spatialconnect.geometries.SCSpatialFeature;
 import com.boundlessgeo.spatialconnect.scutilities.Json.JsonUtilities;
 import com.boundlessgeo.spatialconnect.style.SCStyle;
@@ -138,6 +139,9 @@ public class FormStore extends GeoPackageStore implements ISCSpatialStore, SCDat
         for (HashMap<String, Object> field : config.getFields()) {
             String fieldKey = JsonUtilities.getString(field, SCFormField.FIELD_KEY);
             if (!TextUtils.isEmpty(fieldKey)) {
+                if (SCSqliteHelper.SQLITE_KEYWORDS.contains(fieldKey.toUpperCase())) {
+                    fieldKey = fieldKey + "_";
+                }
                 typeDefs.put(fieldKey, SCFormField.getColumnType(field));
             } else {
                 Log.w(LOG_TAG, String.format("Form field %s was invalid", fieldKey));


### PR DESCRIPTION
## Status
**READY**

This PR fixes issues that we might have if the table name has a colon or a period.  Also this fixes any table or column name that matches a Sqlite keyword.  It also ignores any additional properties that may be part of the form config.