### PR TITLE
fixing bugs with invalid column names & multi* geometries

### DIFF
--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/GeoPackage.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/GeoPackage.java
@@ -214,8 +214,10 @@ public class GeoPackage {
                         String columnName;
                         String columnType;
                         while (cursor.moveToNext()) {
-                            columnName = SCSqliteHelper.getString(cursor, "name");
-                            columnType  = SCSqliteHelper.getString(cursor, "type");
+                            columnName = SCSqliteHelper.sanitizeColumnName(
+                                SCSqliteHelper.getString(cursor, "name")
+                            );
+                            columnType = SCSqliteHelper.getString(cursor, "type");
                             columns.put(columnName, columnType);
                         }
                         //create audit table trigger
@@ -230,8 +232,10 @@ public class GeoPackage {
                     String columnName;
                     String columnType;
                     while (cursor.moveToNext()) {
-                        columnName = SCSqliteHelper.getString(cursor, "name");
-                        columnType  = SCSqliteHelper.getString(cursor, "type");
+                        columnName = SCSqliteHelper.sanitizeColumnName(
+                            SCSqliteHelper.getString(cursor, "name")
+                        );
+                        columnType = SCSqliteHelper.getString(cursor, "type");
                         featureFields.put(columnName, columnType);
                     }
 
@@ -484,11 +488,13 @@ public class GeoPackage {
                         // build a feature source from the table schema
                         SCGpkgFeatureSource source = createFeatureSource(tableName);
                         while (cursor.moveToNext()) {
-                            String columnName = SCSqliteHelper.getString(cursor, "name");
+                            String columnName = SCSqliteHelper.sanitizeColumnName(
+                                SCSqliteHelper.getString(cursor, "name")
+                            );
                             if (SCSqliteHelper.getString(cursor, "type").equalsIgnoreCase("GEOMETRY")
-                                    || SCSqliteHelper.getString(cursor, "type").equalsIgnoreCase("POINT")
-                                    || SCSqliteHelper.getString(cursor, "type").equalsIgnoreCase("LINESTRING")
-                                    || SCSqliteHelper.getString(cursor, "type").equalsIgnoreCase("POLYGON")) {
+                                    || SCSqliteHelper.getString(cursor, "type").contains("POINT")
+                                    || SCSqliteHelper.getString(cursor, "type").contains("LINESTRING")
+                                    || SCSqliteHelper.getString(cursor, "type").contains("POLYGON")) {
                                 source.setGeomColumnName(columnName);
                             }
                             else if (SCSqliteHelper.getInt(cursor, "pk") == 1) {
@@ -503,7 +509,6 @@ public class GeoPackage {
                 })
                 .toList();
     }
-
 
     public Observable<List<SCGpkgTileSource>> getTileTables() {
         return Observable.from(getGeoPackageContents())

--- a/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/SCSqliteHelper.java
+++ b/spatialconnect/src/main/java/com/boundlessgeo/spatialconnect/db/SCSqliteHelper.java
@@ -22,6 +22,8 @@ import android.util.Log;
 import com.squareup.sqlbrite.BriteDatabase;
 import com.squareup.sqlbrite.SqlBrite;
 
+import java.util.Arrays;
+import java.util.List;
 import org.sqlite.database.DatabaseErrorHandler;
 import org.sqlite.database.sqlite.SQLiteDatabase;
 import org.sqlite.database.sqlite.SQLiteOpenHelper;
@@ -35,6 +37,24 @@ import rx.schedulers.Schedulers;
  * provides a {@link BriteDatabase} object which can be used to provide observable sql queries.
  */
 public class SCSqliteHelper extends SQLiteOpenHelper {
+
+    private static final String KEYWORDS = "ABORT,ACTION,ADD,AFTER"
+        + ",ALL,ALTER,ANALYZE,AND,AS,ASC,ATTACH,AUTOINCREMENT,BEFORE,BEGIN,BETWEEN,BY,CASCADE"
+        + ",CASE,CAST,CHECK,COLLATE,COLUMN,COMMIT,CONFLICT,CONSTRAINT,CREATE,CROSS,CURRENT_DATE"
+        + ",CURRENT_TIME,CURRENT_TIMESTAMP,DATABASE,DEFAULT,DEFERRABLE,DEFERRED,DELETE,DESC"
+        + ",DETACH,DISTINCT,DROP,EACH,ELSE,END,ESCAPE,EXCEPT,EXCLUSIVE,EXISTS,EXPLAIN,FAIL,FOR"
+        + ",FOREIGN,FROM,FULL,GLOB,GROUP,HAVING,IF,IGNORE,IMMEDIATE,IN,INDEX,INDEXED,INITIALLY"
+        + ",INNER,INSERT,INSTEAD,INTERSECT,INTO,IS,ISNULL,JOIN,KEY,LEFT,LIKE,LIMIT,MATCH,NATURAL"
+        + ",NO,NOT,NOTNULL,NULL,OF,OFFSET,ON,OR,ORDER,OUTER,PLAN,PRAGMA,PRIMARY,QUERY,RAISE"
+        + ",RECURSIVE,REFERENCES,REGEXP,REINDEX,RELEASE,RENAME,REPLACE,RESTRICT,RIGHT,ROLLBACK"
+        + ",ROW,SAVEPOINT,SELECT,SET,TABLE,TEMP,TEMPORARY,THEN,TO,TRANSACTION,TRIGGER,UNION"
+        + ",UNIQUE,UPDATE,USING,VACUUM,VALUES,VIEW,VIRTUAL,WHEN,WHERE,WITH,WITHOUT";
+
+    /**
+     * A list of keywords used by Sqlite that we cannot use as table or column names.
+     * https://www.sqlite.org/lang_keywords.html
+     */
+    public static final List<String> SQLITE_KEYWORDS = Arrays.asList(KEYWORDS.split(","));
 
     private static final int DATABASE_VERSION = 1;
     private SqlBrite sqlBrite = SqlBrite.create(new SqlBrite.Logger() {
@@ -141,5 +161,13 @@ public class SCSqliteHelper extends SQLiteOpenHelper {
 
     public static byte[] getBlob(Cursor cursor, String columnName) {
         return cursor.getBlob(cursor.getColumnIndexOrThrow(columnName));
+    }
+
+    public static synchronized String sanitizeColumnName(String columnName) {
+        if (columnName.contains(":") ||
+            SCSqliteHelper.SQLITE_KEYWORDS.contains(columnName.toUpperCase())) {
+            return String.format("'%s'", columnName);
+        }
+        return columnName;
     }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
When a GeoPackage is downloaded, it can potentially have column names that cause problems when querying.  Specifically, if a column name contains a colon like `addr:city` or if it is one of the [Sqlite keywords](https://www.sqlite.org/lang_keywords.html) then you have to escape it with single quotes when making SQL queries. 

The other change I made allows `MultiPoint`, `MultiLineStrings`, and `MultiPolygon` geometries to be included in an `SCGpkgFeatureSource`